### PR TITLE
Fix identity url and ratelimit

### DIFF
--- a/tap_marketo/__init__.py
+++ b/tap_marketo/__init__.py
@@ -38,7 +38,7 @@ def get_start(entity):
 
 
 def refresh_token():
-    url = CONFIG['identity'] + "/oauth/token"
+    url = CONFIG['identity'] + "oauth/token"
     params = {
         'grant_type': "client_credentials",
         'client_id': CONFIG['client_id'],

--- a/tap_marketo/utils.py
+++ b/tap_marketo/utils.py
@@ -1,6 +1,5 @@
 import argparse
 import datetime
-import functools
 import json
 import os
 import threading
@@ -14,26 +13,6 @@ def strptime(dt):
 
 def strftime(dt):
     return dt.strftime(DATETIME_FMT)
-
-
-def ratelimit(limit, every):
-    def limitdecorator(fn):
-        semaphore = threading.Semaphore(limit)
-
-        @functools.wraps(fn)
-        def wrapper(*args, **kwargs):
-            semaphore.acquire()
-            try:
-                result = fn(*args, **kwargs)
-            finally:
-                timer = threading.Timer(every, semaphore.release)
-                timer.setDaemon(True)  # allows the timer to be canceled on exit
-                timer.start()
-                return result
-
-        return wrapper
-
-    return limitdecorator
 
 
 def chunk(l, n):


### PR DESCRIPTION
Marketo was failing with an error from the ratelimit function. I rewrote that function to make it simpler. It was using a background thread and a semaphore, and there's really no reason to involve multiple threads here. I changed that for a rate limit of `n` calls per `m` seconds it uses a deque of the last `n` times (seconds since epoch) that it called the function. Then once the deque has over `n` items, every time we go to call the fn, we pop a t `t0` off, and compare it to the current time `t`. If `t - t0 < m` we sleep for the remainder of the time.

Once I fixed that, I was able to see the real cause, which was that we had an extra slash in the URL for the token. I removed the slash.

I ran it locally and it succeeded, fetching a bunch of stuff and then exiting 0. I added some debug logging and confirmed that the ratelimit function was sleeping at seemingly appropriate times.

@iterati I'm curious to hear if you have a suggestion for a more idiomatic way of doing rate limiting. Should we put something like that in `singer-python`?