### PR TITLE
Export start must be passed

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -107,7 +107,8 @@ class TestSyncLeads(unittest.TestCase):
         query = {"updatedAt": {"startAt": pendulum.now().isoformat(), "endAt": pendulum.now().add(days=30).isoformat()}}
         export_info = get_or_create_export_for_leads(self.client, mock_state, \
                                                    self.stream, \
-                                                   fields)
+                                                     fields,
+                                                     pendulum.now())
         self.assertEqual(export_info, (5678, pendulum.parse(export_end)))
 
     @freezegun.freeze_time("2017-01-15")


### PR DESCRIPTION
In the case of no corona, the bookmark date should never change during the while loop.  This means all functions related to leads cannot use the state as a pointer during the export.  