### PR TITLE
Change activity stream names

### DIFF
--- a/tap_marketo/discover.py
+++ b/tap_marketo/discover.py
@@ -65,8 +65,11 @@ def get_activity_type_stream(activity):
         "activityTypeId": {"type": "integer", "inclusion": "automatic"},
     }
 
+    mdata = metadata.new()
+    
     if "primaryAttribute" in activity:
         primary = clean_string(activity["primaryAttribute"]["name"])
+        mdata = metadata.write(mdata, (), 'primary_attribute_name', primary)
         properties[primary] = get_schema_for_type(activity["primaryAttribute"]["dataType"], null=False)
 
     if "attributes" in activity:
@@ -77,7 +80,8 @@ def get_activity_type_stream(activity):
                 properties[attr_name] = field_schema
 
     activity_type_camel = clean_string(activity["name"])
-    mdata = metadata.write({}, (), 'activity_id', activity["id"])
+    mdata = metadata.write(mdata, (), 'activity_id', activity["id"])
+
     tap_stream_id = "activities_{}".format(activity_type_camel)
     
     return {

--- a/tap_marketo/discover.py
+++ b/tap_marketo/discover.py
@@ -63,6 +63,9 @@ def get_activity_type_stream(activity):
         "leadId": {"type": "integer", "inclusion": "automatic"},
         "activityDate": {"type": "string", "format": "date-time", "inclusion": "automatic"},
         "activityTypeId": {"type": "integer", "inclusion": "automatic"},
+        "primaryAttributeValue": {"type": "string", "inclusion": "automatic"},
+        "primaryAttributeName": {"type": "string", "inclusion": "automatic"},
+        "primaryAttributeValueId": {"type": "string", "inclusion": "automatic"},    
     }
 
     mdata = metadata.new()
@@ -70,7 +73,6 @@ def get_activity_type_stream(activity):
     if "primaryAttribute" in activity:
         primary = clean_string(activity["primaryAttribute"]["name"])
         mdata = metadata.write(mdata, (), 'primary_attribute_name', primary)
-        properties[primary] = get_schema_for_type(activity["primaryAttribute"]["dataType"], null=False)
 
     if "attributes" in activity:
         for attr in activity["attributes"]:

--- a/tap_marketo/discover.py
+++ b/tap_marketo/discover.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 import singer
-
+from singer import metadata
 
 STRING_TYPES = [
     'string',
@@ -76,13 +76,17 @@ def get_activity_type_stream(activity):
             if field_schema:
                 properties[attr_name] = field_schema
 
-    tap_stream_id = "activities_{}".format(activity["id"])
+    activity_type_camel = clean_string(activity["name"])
+    mdata = metadata.write({}, (), 'activity_id', activity["id"])
+    tap_stream_id = "activities_{}".format(activity_type_camel)
+    
     return {
         "tap_stream_id": tap_stream_id,
         "stream": tap_stream_id,
         "key_properties": ["marketoGUID"],
         "replication_key": "activityDate",
         "replication_method": "INCREMENTAL",
+        "metadata": metadata.to_list(mdata),
         "schema": {
             "type": "object",
             "additionalProperties": False,

--- a/tap_marketo/discover.py
+++ b/tap_marketo/discover.py
@@ -58,6 +58,10 @@ def get_activity_type_stream(activity):
     # fields. primaryAttribute has a name and type which define an
     # automatically included field on the record. Attributes is an array
     # of attribute names and types that become available fields.
+
+    # Regarding pimaryAttribute fields: On this side of things, Marketo will
+    # describe the field in an activity that is considered the primary attribute
+    # On the sync side, we will have to present that information in a flattened record
     properties = {
         "marketoGUID": {"type": "string", "inclusion": "automatic"},
         "leadId": {"type": "integer", "inclusion": "automatic"},

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -75,7 +75,9 @@ def flatten_activity(row, stream):
     # Move the primary attribute to the named column
     mdata = metadata.to_map(stream['metadata'])
     field = metadata.get(mdata, (), 'primary_attribute_name')
-    rtn[field] = row["primaryAttributeValue"]
+    if field:
+        singer.log_info("primary attribute name is \" %s \" for stream %s", field, stream['tap_stream_id'])
+        rtn[field] = row["primaryAttributeValue"]
 
     # Now flatten the attrs json to it's selected columns
     if "attributes" in row:

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -43,6 +43,8 @@ def format_value(value, schema):
         return pendulum.parse(value).isoformat()
     elif "integer" in field_type:
         return int(value)
+    elif "string" in field_type:
+        return str(value)
     elif "number" in field_type:
         return float(value)
     elif "boolean" in field_type:

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -75,6 +75,8 @@ def flatten_activity(row, stream):
     rtn = {field: row[field] for field in BASE_ACTIVITY_FIELDS}
 
     # Add the primary attribute name
+    # This name is the human readable name/description of the
+    # pimaryAttribute
     mdata = metadata.to_map(stream['metadata'])
     pan_field = metadata.get(mdata, (), 'primary_attribute_name')
     if pan_field:

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -70,7 +70,6 @@ def parse_csv_line(line):
 
 
 def flatten_activity(row, stream):
-    schema = stream['schema']
     # Start with the base fields
     rtn = {field: row[field] for field in BASE_ACTIVITY_FIELDS}
 

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -72,12 +72,14 @@ def flatten_activity(row, stream):
     # Start with the base fields
     rtn = {field: row[field] for field in BASE_ACTIVITY_FIELDS}
 
-    # Move the primary attribute to the named column
+    # Add the primary attribute name
     mdata = metadata.to_map(stream['metadata'])
-    field = metadata.get(mdata, (), 'primary_attribute_name')
-    if field:
-        singer.log_info("primary attribute name is \" %s \" for stream %s", field, stream['tap_stream_id'])
-        rtn[field] = row["primaryAttributeValue"]
+    pan_field = metadata.get(mdata, (), 'primary_attribute_name')
+    if pan_field:
+        singer.log_info("primary attribute name is \" %s \" for stream %s", pan_field, stream['tap_stream_id'])
+        rtn['primaryAttributeName'] = pan_field
+        rtn['primaryAttributeValue'] = row['primaryAttributeValue']
+        rtn['primaryAttributeValueId'] = row['primaryAttributeValueId']
 
     # Now flatten the attrs json to it's selected columns
     if "attributes" in row:

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -36,7 +36,8 @@ class TestDiscover(unittest.TestCase):
             "replication_key": "activityDate",
             "replication_method": "INCREMENTAL",
             "metadata": [{'breadcrumb': (),
-                          'metadata': {'activity_id': 1}}],
+                          'metadata': {'activity_id': 1,
+                                       'primary_attribute_name': 'webpage_id'}}],
             "schema": {
                 "type": "object",
                 "additionalProperties": False,

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -30,11 +30,13 @@ class TestDiscover(unittest.TestCase):
         }
 
         stream = {
-            "tap_stream_id": "activities_1",
-            "stream": "activities_1",
+            "tap_stream_id": "activities_visit_webpage",
+            "stream": "activities_visit_webpage",
             "key_properties": ["marketoGUID"],
             "replication_key": "activityDate",
             "replication_method": "INCREMENTAL",
+            "metadata": [{'breadcrumb': (),
+                          'metadata': {'activity_id': 1}}],
             "schema": {
                 "type": "object",
                 "additionalProperties": False,

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -60,10 +60,18 @@ class TestDiscover(unittest.TestCase):
                         "type": "integer",
                         "inclusion": "automatic",
                     },
-                    "webpage_id": {
-                        "type": "integer",
+                    "primaryAttributeName": {
+                        "type": "string",
                         "inclusion": "automatic",
-                    },
+                    },                    
+                    "primaryAttributeValueId": {
+                        "type": "string",
+                        "inclusion": "automatic",
+                    },                    
+                    "primaryAttributeValue": {
+                        "type": "string",
+                        "inclusion": "automatic",
+                    },                                        
                     "client_ip_address": {
                         "type": ["string", "null"],
                         "inclusion": "available",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -230,7 +230,8 @@ class TestSyncActivities(unittest.TestCase):
             "replication_key": "activityDate",
             "replication_method": "INCREMENTAL",
             "metadata": [{'breadcrumb': (),
-                          'metadata': {'activity_id': 1}}],
+                          'metadata': {'activity_id': 1,
+                                       'primary_attribute_name': 'webpage_id'}}],
             "schema": {
                 "type": "object",
                 "additionalProperties": False,
@@ -319,7 +320,7 @@ class TestSyncActivities(unittest.TestCase):
             "client_ip_address": "0.0.0.0",
             "query_parameters": "",
         }
-        self.assertDictEqual(expected, flatten_activity(row, self.stream["schema"]))
+        self.assertDictEqual(expected, flatten_activity(row, self.stream))
 
     def test_get_or_create_export_get_export_id(self):
         state = {"bookmarks": {"activities_activity_name": {"export_id": "123", "export_end": "2017-01-01T00:00:00Z"}}}

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -243,6 +243,18 @@ class TestSyncActivities(unittest.TestCase):
                         "inclusion": "automatic",
                         "selected": True,
                     },
+                    "primaryAttributeName": {
+                        "type": "string",
+                        "inclusion": "automatic",
+                    },                    
+                    "primaryAttributeValueId": {
+                        "type": "string",
+                        "inclusion": "automatic",
+                    },                    
+                    "primaryAttributeValue": {
+                        "type": "string",
+                        "inclusion": "automatic",
+                    },                    
                     "leadId": {
                         "type": "integer",
                         "inclusion": "automatic",
@@ -255,11 +267,6 @@ class TestSyncActivities(unittest.TestCase):
                         "selected": True,
                     },
                     "activityTypeId": {
-                        "type": "integer",
-                        "inclusion": "automatic",
-                        "selected": True,
-                    },
-                    "webpage_id": {
                         "type": "integer",
                         "inclusion": "automatic",
                         "selected": True,
@@ -285,6 +292,9 @@ class TestSyncActivities(unittest.TestCase):
             "activityDate": "2017-01-01T00:00:00Z",
             "activityTypeId": "1",
             "webpage_id": "123",
+            "primaryAttributeName": "Webpage Id",
+            "primaryAttributeValue": "123",
+            "primaryAttributeValueId": None,
             "client_ip_address": "0.0.0.0",
             "query_parameters": "",
         }
@@ -293,7 +303,9 @@ class TestSyncActivities(unittest.TestCase):
             "leadId": 123,
             "activityDate": "2017-01-01T00:00:00+00:00",
             "activityTypeId": 1,
-            "webpage_id": 123,
+            "primaryAttributeName": "Webpage Id",
+            "primaryAttributeValue": "123",
+            "primaryAttributeValueId": None,
             "client_ip_address": "0.0.0.0",
         }
         self.assertDictEqual(expected, format_values(self.stream, row))
@@ -316,9 +328,11 @@ class TestSyncActivities(unittest.TestCase):
             "leadId": "123",
             "activityDate": "2017-01-01T00:00:00Z",
             "activityTypeId": "1",
-            "webpage_id": "123",
             "client_ip_address": "0.0.0.0",
             "query_parameters": "",
+            "primaryAttributeName": 'webpage_id',
+            "primaryAttributeValue": "123",
+            "primaryAttributeValueId": ""
         }
         self.assertDictEqual(expected, flatten_activity(row, self.stream))
 
@@ -381,11 +395,11 @@ class TestSyncActivities(unittest.TestCase):
                                                 "export_id": "123",
                                                 "export_end": "2017-01-15T00:00:00+00:00"}}}
         lines = [
-            b'marketoGUID,leadId,activityDate,activityTypeId,primaryAttributeValue,attributes',
-            b'1,1,2016-12-31T00:00:00+00:00,1,1,{"Client IP Address":"0.0.0.0"}',
-            b'2,2,2017-01-01T00:00:00+00:00,1,1,{"Client IP Address":"0.0.0.0"}',
-            b'3,3,2017-01-02T00:00:00+00:00,1,1,{"Client IP Address":"0.0.0.0"}',
-            b'4,4,2017-01-03T00:00:00+00:00,1,1,{"Client IP Address":"0.0.0.0"}',
+            b'marketoGUID,leadId,activityDate,activityTypeId,primaryAttributeValue,primaryAttributeValueId,attributes',
+            b'1,1,2016-12-31T00:00:00+00:00,1,1,,{"Client IP Address":"0.0.0.0"}',
+            b'2,2,2017-01-01T00:00:00+00:00,1,1,,{"Client IP Address":"0.0.0.0"}',
+            b'3,3,2017-01-02T00:00:00+00:00,1,1,,{"Client IP Address":"0.0.0.0"}',
+            b'4,4,2017-01-03T00:00:00+00:00,1,1,,{"Client IP Address":"0.0.0.0"}',
         ]
 
         self.client.wait_for_export = unittest.mock.MagicMock(return_value=True)
@@ -405,12 +419,12 @@ class TestSyncActivities(unittest.TestCase):
         expected_calls = [
             unittest.mock.call("activities_activity_name",
                                {"marketoGUID": "2", "leadId": 2, "activityDate": "2017-01-01T00:00:00+00:00",
-                                "activityTypeId": 1, "webpage_id": 1, "client_ip_address": "0.0.0.0"}),
+                                "activityTypeId": 1, "primaryAttributeValueId": None, "primaryAttributeName": "webpage_id", "primaryAttributeValue": '1', "client_ip_address": "0.0.0.0"}),
             unittest.mock.call("activities_activity_name",
                                {"marketoGUID": "3", "leadId": 3, "activityDate": "2017-01-02T00:00:00+00:00",
-                                "activityTypeId": 1, "webpage_id": 1, "client_ip_address": "0.0.0.0"}),
+                                "activityTypeId": 1, "primaryAttributeValueId": None, "primaryAttributeName": "webpage_id", "primaryAttributeValue": '1', "client_ip_address": "0.0.0.0"}),
             unittest.mock.call("activities_activity_name",
                                {"marketoGUID": "4", "leadId": 4, "activityDate": "2017-01-03T00:00:00+00:00",
-                                "activityTypeId": 1, "webpage_id": 1, "client_ip_address": "0.0.0.0"}),
+                                "activityTypeId": 1, "primaryAttributeValueId": None, "primaryAttributeName": "webpage_id", "primaryAttributeValue": '1', "client_ip_address": "0.0.0.0"}),
         ]
         write_record.assert_has_calls(expected_calls)


### PR DESCRIPTION
Make activity stream names human readable and put the activity id into the metadata.

Also, deal with primaryAttribute nonsense.  Keep all PrimaryAttribute<> fields, and manually add in an PrimaryAttributeName field.  This way we are transforming as little as possible.

Raw record from Marketo:
```
{'attributes': '{"Reason":"Manual lead edit","New Value":"hello","Old Value":null,"Source":"Lead update"}',
 'primaryAttributeValueId': '52', 
'primaryAttributeValue': 'Salutation', 
'leadId': '351', 'activityTypeId': '13', 'activityDate': '2017-10-17T20:28:32Z', 'marketoGUID': '710'}
```

Send to Stitch:
```
{"marketoGUID": "710", "leadId": 351, "source": "Lead update", 
"primaryAttributeValueId": "52", 
"activityDate": "2017-10-17T20:28:32+00:00", "new_value": "hello", "reason": "Manual lead edit", "activityTypeId": 13, 
"primaryAttributeName": "attribute_name",
"primaryAttributeValue": "Salutation", "old_value": null}, "action": "upsert", "vintage": "2017-10-18T15:06:40.307519+00:00", "sequence": 1508339200307}
```