### PR TITLE
Add inclusion metadata

### DIFF
--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -80,9 +80,9 @@ def flatten_activity(row, stream):
     pan_field = metadata.get(mdata, (), 'primary_attribute_name')
     if pan_field:
         singer.log_info("primary attribute name is \" %s \" for stream %s", pan_field, stream['tap_stream_id'])
-        rtn['primaryAttributeName'] = pan_field
-        rtn['primaryAttributeValue'] = row['primaryAttributeValue']
-        rtn['primaryAttributeValueId'] = row['primaryAttributeValueId']
+        rtn['primary_attribute_name'] = pan_field
+        rtn['primary_attribute_value'] = row['primaryAttributeValue']
+        rtn['primary_attribute_value_id'] = row['primaryAttributeValueId']
 
     # Now flatten the attrs json to it's selected columns
     if "attributes" in row:

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -35,9 +35,6 @@ class TestDiscover(unittest.TestCase):
             "key_properties": ["marketoGUID"],
             "replication_key": "activityDate",
             "replication_method": "INCREMENTAL",
-            "metadata": [{'breadcrumb': (),
-                          'metadata': {'activity_id': 1,
-                                       'primary_attribute_name': 'webpage_id'}}],
             "schema": {
                 "type": "object",
                 "additionalProperties": False,
@@ -60,15 +57,15 @@ class TestDiscover(unittest.TestCase):
                         "type": "integer",
                         "inclusion": "automatic",
                     },
-                    "primaryAttributeName": {
+                    "primary_attribute_name": {
                         "type": "string",
                         "inclusion": "automatic",
                     },                    
-                    "primaryAttributeValueId": {
+                    "primary_attribute_value_id": {
                         "type": "string",
                         "inclusion": "automatic",
                     },                    
-                    "primaryAttributeValue": {
+                    "primary_attribute_value": {
                         "type": "string",
                         "inclusion": "automatic",
                     },                                        
@@ -83,8 +80,11 @@ class TestDiscover(unittest.TestCase):
                 },
             },
         }
-
-        self.assertDictEqual(stream, get_activity_type_stream(activity))
+        self.maxDiff = None
+        result = get_activity_type_stream(activity)
+        metadata = result.pop("metadata")
+        self.assertDictEqual(stream, result)
+        self.assertEqual(10, len(metadata))
 
     def test_discover_leads(self):
         client = Client("123-ABC-456", "id", "secret")
@@ -105,6 +105,10 @@ class TestDiscover(unittest.TestCase):
             "key_properties": ["id"],
             "replication_key": "updatedAt",
             "replication_method": "INCREMENTAL",
+            "metadata": [{'breadcrumb': ('properties', 'foo'),
+                          'metadata': {'inclusion': 'available'}},
+                         {'breadcrumb': ('properties', 'id'),
+                          'metadata': {'inclusion': 'automatic'}}],
             "schema": {
                 "type": "object",
                 "additionalProperties": False,

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -80,11 +80,15 @@ class TestDiscover(unittest.TestCase):
                 },
             },
         }
-        self.maxDiff = None
         result = get_activity_type_stream(activity)
         metadata = result.pop("metadata")
+        automatic_count = 0
+        for mdata in metadata:
+            if mdata['metadata'].get('inclusion') == 'automatic':
+                automatic_count += 1        
         self.assertDictEqual(stream, result)
         self.assertEqual(10, len(metadata))
+        self.assertEqual(7,automatic_count)
 
     def test_discover_leads(self):
         client = Client("123-ABC-456", "id", "secret")
@@ -105,10 +109,6 @@ class TestDiscover(unittest.TestCase):
             "key_properties": ["id"],
             "replication_key": "updatedAt",
             "replication_method": "INCREMENTAL",
-            "metadata": [{'breadcrumb': ('properties', 'foo'),
-                          'metadata': {'inclusion': 'available'}},
-                         {'breadcrumb': ('properties', 'id'),
-                          'metadata': {'inclusion': 'automatic'}}],
             "schema": {
                 "type": "object",
                 "additionalProperties": False,
@@ -128,4 +128,13 @@ class TestDiscover(unittest.TestCase):
 
         with requests_mock.Mocker(real_http=True) as mock:
             mock.register_uri("GET", client.get_url("rest/v1/leads/describe.json"), json=data)
-            self.assertDictEqual(stream, discover_leads(client))
+            self.maxDiff = None
+            result = discover_leads(client)
+            metadata = result.pop("metadata")
+            automatic_count = 0
+            for mdata in metadata:
+                if mdata['metadata']['inclusion'] == 'automatic':
+                    automatic_count += 1
+            self.assertDictEqual(stream, result)
+            self.assertEqual(2,len(metadata))
+            self.assertEqual(1,automatic_count)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -7,7 +7,9 @@ import pendulum
 import requests_mock
 
 from tap_marketo.client import Client, ApiException
-from tap_marketo.discover import discover_catalog
+from tap_marketo.discover import (discover_catalog,
+                                  ACTIVITY_TYPES_AUTOMATIC_INCLUSION,
+                                  PROGRAMS_AUTOMATIC_INCLUSION)
 from tap_marketo.sync import *
 
 
@@ -20,7 +22,7 @@ class TestSyncActivityTypes(unittest.TestCase):
         self.client = Client("123-ABC-456", "id", "secret")
         self.client.token_expires = pendulum.utcnow().add(days=1)
         self.client.calls_today = 1
-        self.stream = discover_catalog("activity_types")
+        self.stream = discover_catalog("activity_types", ACTIVITY_TYPES_AUTOMATIC_INCLUSION, True)
         for schema in self.stream["schema"]["properties"].values():
             schema["selected"] = True
 
@@ -175,7 +177,7 @@ class TestSyncPaginated(unittest.TestCase):
         self.client = Client("123-ABC-456", "id", "secret")
         self.client.token_expires = pendulum.utcnow().add(days=1)
         self.client.calls_today = 1
-        self.stream = discover_catalog("programs")
+        self.stream = discover_catalog("programs", PROGRAMS_AUTOMATIC_INCLUSION)
 
     def test_sync_paginated(self):
         state = {"bookmarks": {"programs": {"updatedAt": "2017-01-01T00:00:00Z", "next_page_token": "abc"}}}
@@ -243,15 +245,15 @@ class TestSyncActivities(unittest.TestCase):
                         "inclusion": "automatic",
                         "selected": True,
                     },
-                    "primaryAttributeName": {
+                    "primary_attribute_name": {
                         "type": "string",
                         "inclusion": "automatic",
                     },                    
-                    "primaryAttributeValueId": {
+                    "primary_attribute_value_id": {
                         "type": "string",
                         "inclusion": "automatic",
                     },                    
-                    "primaryAttributeValue": {
+                    "primary_attribute_value": {
                         "type": "string",
                         "inclusion": "automatic",
                     },                    
@@ -292,9 +294,9 @@ class TestSyncActivities(unittest.TestCase):
             "activityDate": "2017-01-01T00:00:00Z",
             "activityTypeId": "1",
             "webpage_id": "123",
-            "primaryAttributeName": "Webpage Id",
-            "primaryAttributeValue": "123",
-            "primaryAttributeValueId": None,
+            "primary_attribute_name": "Webpage Id",
+            "primary_attribute_value": "123",
+            "primary_attribute_value_id": None,
             "client_ip_address": "0.0.0.0",
             "query_parameters": "",
         }
@@ -303,9 +305,9 @@ class TestSyncActivities(unittest.TestCase):
             "leadId": 123,
             "activityDate": "2017-01-01T00:00:00+00:00",
             "activityTypeId": 1,
-            "primaryAttributeName": "Webpage Id",
-            "primaryAttributeValue": "123",
-            "primaryAttributeValueId": None,
+            "primary_attribute_name": "Webpage Id",
+            "primary_attribute_value": "123",
+            "primary_attribute_value_id": None,
             "client_ip_address": "0.0.0.0",
         }
         self.assertDictEqual(expected, format_values(self.stream, row))
@@ -330,9 +332,9 @@ class TestSyncActivities(unittest.TestCase):
             "activityTypeId": "1",
             "client_ip_address": "0.0.0.0",
             "query_parameters": "",
-            "primaryAttributeName": 'webpage_id',
-            "primaryAttributeValue": "123",
-            "primaryAttributeValueId": ""
+            "primary_attribute_name": 'webpage_id',
+            "primary_attribute_value": "123",
+            "primary_attribute_value_id": ""
         }
         self.assertDictEqual(expected, flatten_activity(row, self.stream))
 
@@ -419,12 +421,12 @@ class TestSyncActivities(unittest.TestCase):
         expected_calls = [
             unittest.mock.call("activities_activity_name",
                                {"marketoGUID": "2", "leadId": 2, "activityDate": "2017-01-01T00:00:00+00:00",
-                                "activityTypeId": 1, "primaryAttributeValueId": None, "primaryAttributeName": "webpage_id", "primaryAttributeValue": '1', "client_ip_address": "0.0.0.0"}),
+                                "activityTypeId": 1, "primary_attribute_value_id": None, "primary_attribute_name": "webpage_id", "primary_attribute_value": '1', "client_ip_address": "0.0.0.0"}),
             unittest.mock.call("activities_activity_name",
                                {"marketoGUID": "3", "leadId": 3, "activityDate": "2017-01-02T00:00:00+00:00",
-                                "activityTypeId": 1, "primaryAttributeValueId": None, "primaryAttributeName": "webpage_id", "primaryAttributeValue": '1', "client_ip_address": "0.0.0.0"}),
+                                "activityTypeId": 1, "primary_attribute_value_id": None, "primary_attribute_name": "webpage_id", "primary_attribute_value": '1', "client_ip_address": "0.0.0.0"}),
             unittest.mock.call("activities_activity_name",
                                {"marketoGUID": "4", "leadId": 4, "activityDate": "2017-01-03T00:00:00+00:00",
-                                "activityTypeId": 1, "primaryAttributeValueId": None, "primaryAttributeName": "webpage_id", "primaryAttributeValue": '1', "client_ip_address": "0.0.0.0"}),
+                                "activityTypeId": 1, "primary_attribute_value_id": None, "primary_attribute_name": "webpage_id", "primary_attribute_value": '1', "client_ip_address": "0.0.0.0"}),
         ]
         write_record.assert_has_calls(expected_calls)


### PR DESCRIPTION
This branch does a couple things.

Fix bug in automatic inclusion logic

introduce metadata on discover side of things.  We're waiting on other changes before we can leverage metadata inclusion information during the sync.

Improve logging.