### PR TITLE
Fix/filter null lead

### DIFF
--- a/tap_marketo/client.py
+++ b/tap_marketo/client.py
@@ -179,7 +179,7 @@ class Client:
             if resp.status_code != 200:
                 raise ApiException("Marketo API returned error: {0.status_code}: {0.content}".format(resp))
 
-            return resp.iter_lines()
+            return resp
 
     def create_export(self, stream_type, fields, query):
         # http://developers.marketo.com/rest-api/bulk-extract/#creating_a_job

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -151,20 +151,8 @@ def write_leads_records(client, stream, lines, og_bookmark_value, record_count):
                             quotechar='"')
 
     headers = next(csv_stream)
-    headers_count = len(headers)
 
-    singer.log_info("CSV check: %s", headers)
-
-    for line in csv_stream:
-        line_count = len(line)
-        line_count_failures = 0
-
-        if line_count != headers_count:
-            singer.log_info("Documenting: Badly shaped line.  Headers count: %d Line count: %d", headers_count, line_count)
-            if line_count_failures < 12:
-                singer.log_info("CSV check: %s", line.decode('utf-8'))
-                line_count_failures +=1
-        
+    for line in csv_stream:        
         line = dict(zip(headers, line))
 
         #deal with updatedAt potentially being null

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -1,5 +1,4 @@
 import csv
-import io
 import json
 import pendulum
 import singer

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -98,9 +98,9 @@ class TestSyncLeads(unittest.TestCase):
                                "selected": False,
                            },
                            "attributes": {
-                               "type": "integer",
+                               "type": "string",
                                "inclusion": "available",
-                               "selected": False,
+                               "selected": True,
                            }}}}
 
         self.client.create_export = self.mocked_client_create_export
@@ -167,7 +167,7 @@ class TestSyncLeads(unittest.TestCase):
         state = {"bookmarks": {"leads": {"updatedAt": "2017-01-01T00:00:00+00:00",
                                          "export_id": "123",
                                          "export_end": "2017-01-15T00:00:00+00:00"}}}
-        lines = 'marketoGUID,id,updatedAt,attributes\n1,1,2016-12-31T00:00:00+00:00,1\n2,2,2017-01-01T00:00:00+00:00,1\n3,3,2017-01-02T00:00:00+00:00,1\n4,4,2017-01-03T00:00:00+00:00,1'
+        lines = 'marketoGUID,id,updatedAt,attributes\n1,1,2016-12-31T00:00:00+00:00,"1\n2"\n2,2,2017-01-01T00:00:00+00:00,"1"\n3,3,2017-01-02T00:00:00+00:00,"1"\n4,4,2017-01-03T00:00:00+00:00,"ab\nc"'
 
         self.client.wait_for_export = unittest.mock.MagicMock(return_value=True)
         self.client.stream_export = unittest.mock.MagicMock(return_value=MockResponse(lines))
@@ -185,11 +185,11 @@ class TestSyncLeads(unittest.TestCase):
 
         expected_calls = [
             unittest.mock.call("leads",
-                               {"marketoGUID": "2", "id": 2, "updatedAt": "2017-01-01T00:00:00+00:00"}),
+                               {"marketoGUID": "2", "id": 2, "updatedAt": "2017-01-01T00:00:00+00:00", "attributes": "1"}),
             unittest.mock.call("leads",
-                               {"marketoGUID": "3", "id": 3, "updatedAt": "2017-01-02T00:00:00+00:00"}),
+                               {"marketoGUID": "3", "id": 3, "updatedAt": "2017-01-02T00:00:00+00:00", "attributes": "1"}),
             unittest.mock.call("leads",
-                               {"marketoGUID": "4", "id": 4, "updatedAt": "2017-01-03T00:00:00+00:00"})
+                               {"marketoGUID": "4", "id": 4, "updatedAt": "2017-01-03T00:00:00+00:00", "attributes": "ab\nc"})
         ]
         write_record.assert_has_calls(expected_calls)
 


### PR DESCRIPTION
This PR does two things.

First, it fixes CSV parsing so that newlines present inside double quotes are simply escaped.
Second, it adds a 24 hour attribution window.  This is because during testing is was observed that there is a several hour delay between a UI updated and the changing of the upatedAt value.  Furthermore, the udpatedAt value was changed retroactively.  This could introduce data discrepancies if we've updated the bookmark to the present time while updatedAt values were being changed to a time in the past.