### PR TITLE
Fix/Retry when rate limited response is received

### DIFF
--- a/tap_marketo/__init__.py
+++ b/tap_marketo/__init__.py
@@ -54,6 +54,8 @@ class RateLimitExceededException(Exception):
     pass
 
 @utils.ratelimit(100, 20)
+# When one of the handlers catches its associated exception, the other handler
+# will be reset back to 0 tries.
 @backoff.on_exception(backoff.expo,
                       (requests.exceptions.RequestException),
                       max_tries=5,

--- a/tap_marketo/__init__.py
+++ b/tap_marketo/__init__.py
@@ -50,6 +50,8 @@ def get_start(entity):
 
     return STATE[entity]
 
+class RateLimitExceededException(Exception):
+    pass
 
 @utils.ratelimit(100, 20)
 @backoff.on_exception(backoff.expo,
@@ -58,6 +60,8 @@ def get_start(entity):
                       giveup=lambda e: e.response is not None and
                       400 <= e.response.status_code < 500,
                       factor=2)
+@backoff.on_exception(backoff.expo,
+                      RateLimitExceededException)
 
 def request(endpoint, params=None):
     if not CONFIG['token_expires'] or datetime.datetime.utcnow() >= CONFIG['token_expires']:
@@ -84,8 +88,12 @@ def request(endpoint, params=None):
 
     if not data['success']:
         reasons = ", ".join("{code}: {message}".format(**err) for err in data['errors'])
-        LOGGER.critical("API call failed. {}".format(reasons))
-        sys.exit(1)
+        if len(data['errors']) == 1 and data['errors'][0]['code'] == "606":
+            LOGGER.warning("Rate limit exceeded. Will try again. (Response: {})".format(reasons))
+            raise RateLimitExceededException()
+        else:
+            LOGGER.critical("API call failed. {}".format(reasons))
+            sys.exit(1)
 
     return data
 


### PR DESCRIPTION
Marketo only allows 100 requests per 20 second period. While we properly implement rate limiting to ensure that we don't exceed this rate, the tap exists whenever it receives an error response from Marketo indicating that this rate limit has been exceeded. This can happen if something else is querying the API concurrently.

This branch adds logic to backoff and retry in the event of an error response indicating that the rate limit has been exceeded. 