### PR TITLE
Feature/add bookmark properties and time extracted

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-marketo',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_marketo'],
       install_requires=[
-          'singer-python==4.0.2',
+          'singer-python==5.0.4',
           'requests==2.12.4',
           'pendulum==1.2.0',
           'freezegun>=0.3.9',


### PR DESCRIPTION
singer-python version 5.0.0 introduced time_extracted for the RecordMessage and bookmark_properties for the SchemaMessage. We are now going to support these in tap-marketo.