### PR TITLE
Note `max_export_days` Config Property if Sync Throws ApiExceptions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,11 @@ setup(name='tap-marketo',
           'freezegun>=0.3.9',
           'requests_mock>=1.3.0'
       ],
+      extras_require={
+          'dev': [
+              'ipdb==0.11'
+          ]
+      },
       entry_points='''
           [console_scripts]
           tap-marketo=tap_marketo:main

--- a/tap_marketo/client.py
+++ b/tap_marketo/client.py
@@ -39,6 +39,10 @@ class ApiException(Exception):
     """Indicates an error occured communicating with the Marketo API."""
 
 
+class ApiQuotaExceeded(Exception):
+    """Indicates that there's no quota left for the API"""
+
+
 class ExportFailed(Exception):
     """Indicates an error occured while attempting a bulk export."""
 
@@ -167,7 +171,7 @@ class Client:
             data = resp.json()
             err_codes = set(err["code"] for err in data.get("errors", []))
             if API_QUOTA_EXCEEDED in err_codes:
-                raise ApiException(API_QUOTA_EXCEEDED_MESSAGE.format(data['errors']))
+                raise ApiQuotaExceeded(API_QUOTA_EXCEEDED_MESSAGE.format(data['errors']))
             elif not data["success"]:
                 err = ", ".join("{code}: {message}".format(**e) for e in data["errors"])
                 raise ApiException("Marketo API returned error(s): {}".format(err))
@@ -289,7 +293,7 @@ class Client:
             singer.log_info("Corona not supported.")
             return False
         elif API_QUOTA_EXCEEDED in err_codes:
-            raise ApiException(API_QUOTA_EXCEEDED_MESSAGE.format(data['errors']))
+            raise ApiQuotaExceeded(API_QUOTA_EXCEEDED_MESSAGE.format(data['errors']))
         else:
             singer.log_info("Corona is supported.")
             singer.log_info(data)

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -184,14 +184,25 @@ def get_or_create_export_for_activities(client, state, stream, export_start, con
         # that is not a real field. `createdAt` proxies `activityDate`.
         # The activity type id must also be included in the query. The
         # largest date range that can be used for activities is 30 days.
-        export_end = get_export_end(export_start, end_days=int(config.get('max_export_days', MAX_EXPORT_DAYS)))
+        max_export_days = int(config.get('max_export_days',
+                                         MAX_EXPORT_DAYS))
+        export_end = get_export_end(export_start,
+                                    end_days=max_export_days)
         query = {"createdAt": {"startAt": export_start.isoformat(),
                                "endAt": export_end.isoformat()},
                  "activityTypeIds": [activity_type_id]}
 
         # Create the new export and store the id and end date in state.
         # Does not start the export (must POST to the "enqueue" endpoint).
-        export_id = client.create_export("activities", ACTIVITY_FIELDS, query)
+        try:
+            export_id = client.create_export("activities", ACTIVITY_FIELDS, query)
+        except client.ApiException as e:
+            raise client.ApiException(
+                ("You may wish to consider changing the "
+                 "`max_export_days` config value to a lower number if "
+                 "you're unable to sync a single {} day window within "
+                 "your current API quota.").format(
+                     max_export_days)) from e
         state = update_state_with_export_info(
             state, stream, export_id=export_id, export_end=export_end.isoformat())
     else:


### PR DESCRIPTION
Motivation
----------

https://stitchdata.atlassian.net/browse/SUP-366

Clients who run into this error may not know about the non-standard config
value which can be used to get around a problem bookmarking a large export.