### PR TITLE
check for empty breadcrumb the right way

### DIFF
--- a/tap_marketo/__init__.py
+++ b/tap_marketo/__init__.py
@@ -35,7 +35,7 @@ REQUIRED_CONFIG_KEYS = [
 def validate_state(config, catalog, state):
     for stream in catalog["streams"]:
         for mdata in stream['metadata']:
-            if mdata['breadcrumb'] == () and mdata['metadata'].get('selected') != True:
+            if mdata['breadcrumb'] == [] and mdata['metadata'].get('selected') != True:
                 # If a stream is deselected while it's the current stream, unset the
                 # current stream.
                 if stream["tap_stream_id"] == get_currently_syncing(state):

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -16,7 +16,7 @@ class TestValidateState(unittest.TestCase):
                     "stream": "activities_visit_webpage",
                     "key_properties": ["marketoGUID"],
                     "metadata" : [
-                        {'breadcrumb': (),
+                        {'breadcrumb': [],
                          'metadata': {'marketo.activity-id': 1,
                                       'selected' : True,
                                       'marketo.primary-attribute-name': 'webpage_id'}},
@@ -24,55 +24,55 @@ class TestValidateState(unittest.TestCase):
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'marketoGUID')
+                            "breadcrumb" : ["properties", 'marketoGUID']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'leadId')
+                            "breadcrumb" : ["properties", 'leadId']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'activityDate')
+                            "breadcrumb" : ["properties", 'activityDate']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'activityTypeId')
+                            "breadcrumb" : ["properties", 'activityTypeId']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'primary_attribute_name')
+                            "breadcrumb" : ["properties", 'primary_attribute_name']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'primary_attribute_value_id')
+                            "breadcrumb" : ["properties", 'primary_attribute_value_id']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'primary_attribute_value')
+                            "breadcrumb" : ["properties", 'primary_attribute_value']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "available"
                             },
-                            "breadcrumb" : ("properties", 'client_ip_address')
+                            "breadcrumb" : ["properties", 'client_ip_address']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "available"
                             },
-                            "breadcrumb" : ("properties", 'query_parameters')
+                            "breadcrumb" : ["properties", 'query_parameters']
                         },
                     ],
                     "schema": {
@@ -115,7 +115,7 @@ class TestValidateState(unittest.TestCase):
                     "stream": "leads",
                     "key_properties": ["marketoGUID"],
                     "metadata" : [
-                        {'breadcrumb': (),
+                        {'breadcrumb': [],
                          'metadata': {'marketo.activity-id': 1,
                                       'selected' : False,
                                       'marketo.primary-attribute-name': 'webpage_id'}},
@@ -123,55 +123,55 @@ class TestValidateState(unittest.TestCase):
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'marketoGUID')
+                            "breadcrumb" : ["properties", 'marketoGUID']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'leadId')
+                            "breadcrumb" : ["properties", 'leadId']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'activityDate')
+                            "breadcrumb" : ["properties", 'activityDate']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'activityTypeId')
+                            "breadcrumb" : ["properties", 'activityTypeId']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'primary_attribute_name')
+                            "breadcrumb" : ["properties", 'primary_attribute_name']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'primary_attribute_value_id')
+                            "breadcrumb" : ["properties", 'primary_attribute_value_id']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "automatic"
                             },
-                            "breadcrumb" : ("properties", 'primary_attribute_value')
+                            "breadcrumb" : ["properties", 'primary_attribute_value']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "available"
                             },
-                            "breadcrumb" : ("properties", 'client_ip_address')
+                            "breadcrumb" : ["properties", 'client_ip_address']
                         },
                         {
                             "metadata" : {
                                 "inclusion": "available"
                             },
-                            "breadcrumb" : ("properties", 'query_parameters')
+                            "breadcrumb" : ["properties", 'query_parameters']
                         },
                     ],
                     "schema": {


### PR DESCRIPTION
# Description of change
When validating the state, check for an empty breadcrumb by checking for an empty list instead of an empty tuple.  

# Manual QA steps
Had a client that was stuck in an infinite loop since they de-selected the stream that was bookmarked as `currently_syncing`.  Was able to verify that this fix takes them out of the looping behavior.
 
# Risks
None since this function was not working correctly before
 
# Rollback steps
Revert this change
