### PR TITLE
Add retry to handle 20 sec quota limit

### DIFF
--- a/tap_marketo/client.py
+++ b/tap_marketo/client.py
@@ -39,7 +39,7 @@ def extract_domain(url):
         raise ValueError("%s is not a valid Marketo URL" % url)
     return result.group()
 
-def retry_persistently(exception):
+def retry_persistently(_exception):
     """
     To be used as a `giveup` parameter in backoff to never giveup for
     certain exception types.


### PR DESCRIPTION
# Description of change
Marketo has a short term quota limit of 100 requests per 20 seconds across all apps using a single Marketo account (or so it seems).

This results in a 606 error code, so this PR will handle that and backoff so as to not interrupt the sync job.

# Manual QA steps
 - Implemented from a specific example and fits in with the current pattern, could not reproduce at will, so testing in a patch version.
 
# Risks
 - Low, it's additive to the error handling. Worst case it doesn't catch the error.
 
# Rollback steps
 - revert this branch and bump version
