### PR TITLE
Better backoff pattern for short term rate limit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,12 @@ setup(name='tap-marketo',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_marketo'],
       install_requires=[
-          'singer-python==5.0.4',
+          'singer-python==5.9.0',
           'requests==2.20.0',
           'pendulum==1.2.0',
           'freezegun>=0.3.9',
-          'requests_mock>=1.3.0'
+          'requests_mock>=1.3.0',
+          'backoff==1.8.0',
       ],
       extras_require={
           'dev': [

--- a/tap_marketo/client.py
+++ b/tap_marketo/client.py
@@ -1,6 +1,7 @@
 import re
 import time
 
+import backoff
 import pendulum
 import requests
 import singer
@@ -39,13 +40,6 @@ def extract_domain(url):
         raise ValueError("%s is not a valid Marketo URL" % url)
     return result.group()
 
-def retry_persistently(_exception):
-    """
-    To be used as a `giveup` parameter in backoff to never giveup for
-    certain exception types.
-    """
-    return False
-
 class ApiException(Exception):
     """Indicates an error occured communicating with the Marketo API."""
 
@@ -63,6 +57,25 @@ class ExportFailed(Exception):
 
     """Indicates an error occured while attempting a bulk export."""
 
+def handle_short_term_rate_limit():
+    return backoff.on_exception(backoff.constant,
+                                (ShortTermQuotaExceeded),
+                                max_tries=5,
+                                interval=4,
+                                jitter=None,
+                                logger=singer.get_logger())
+
+def raise_for_marketo_errors(data):
+    err_codes = set(err["code"] for err in data.get("errors", []))
+    if API_QUOTA_EXCEEDED in err_codes:
+        raise ApiQuotaExceeded(API_QUOTA_EXCEEDED_MESSAGE.format(data['errors']))
+    elif SHORT_TERM_QUOTA_EXCEEDED in err_codes:
+        message = SHORT_TERM_QUOTA_EXCEEDED_MESSAGE.format(data['errors'])
+        singer.log_warning(message)
+        raise ShortTermQuotaExceeded(message)
+    elif not data["success"]:
+        err = ", ".join("{code}: {message}".format(**e) for e in data["errors"])
+        raise ApiException("Marketo API returned error(s): {}".format(err))
 
 class Client:
     # pylint: disable=unused-argument
@@ -166,13 +179,15 @@ class Client:
     def update_calls_today(self):
         # http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Usage/getDailyUsageUsingGET
         data = self._request("GET", "rest/v1/stats/usage.json").json()
+
+        raise_for_marketo_errors(data)
         if "result" not in data:
             raise ApiException(data)
 
         self.calls_today = int(data["result"][0]["total"])
         singer.log_info("Used %s of %s requests", self.calls_today, self.max_daily_calls)
 
-    @singer.utils.backoff((ShortTermQuotaExceeded), retry_persistently)
+    @handle_short_term_rate_limit()
     def request(self, method, url, endpoint_name=None, **kwargs):
         if self.calls_today % 250 == 0:
             self.update_calls_today()
@@ -187,16 +202,7 @@ class Client:
                 return {}
 
             data = resp.json()
-            err_codes = set(err["code"] for err in data.get("errors", []))
-            if API_QUOTA_EXCEEDED in err_codes:
-                raise ApiQuotaExceeded(API_QUOTA_EXCEEDED_MESSAGE.format(data['errors']))
-            elif SHORT_TERM_QUOTA_EXCEEDED in err_codes:
-                message = SHORT_TERM_QUOTA_EXCEEDED_MESSAGE.format(data['errors'])
-                singer.log_warning(message)
-                raise ShortTermQuotaExceeded(message)
-            elif not data["success"]:
-                err = ", ".join("{code}: {message}".format(**e) for e in data["errors"])
-                raise ApiException("Marketo API returned error(s): {}".format(err))
+            raise_for_marketo_errors(data)
 
             return data
         else:
@@ -283,6 +289,7 @@ class Client:
 
         raise ExportFailed("Export timed out after {} minutes".format(self.job_timeout / 60))
 
+    @handle_short_term_rate_limit()
     def test_corona(self):
         # http://developers.marketo.com/rest-api/bulk-extract/#limits
         # Corona allows us to do bulk queries for Leads using updatedAt
@@ -306,6 +313,8 @@ class Client:
         endpoint = self.get_bulk_endpoint("leads", "create")
         data = self._request("POST", endpoint, endpoint_name="leads_create", json=payload).json()
 
+        raise_for_marketo_errors(data)
+
         # If the error code indicating no Corona support is present,
         # Corona is not supported. If we don't get that error code,
         # Corona is supported and we need to clean up by cancelling the
@@ -314,8 +323,6 @@ class Client:
         if NO_CORONA_CODE in err_codes:
             singer.log_info("Corona not supported.")
             return False
-        elif API_QUOTA_EXCEEDED in err_codes:
-            raise ApiQuotaExceeded(API_QUOTA_EXCEEDED_MESSAGE.format(data['errors']))
         else:
             singer.log_info("Corona is supported.")
             singer.log_info(data)


### PR DESCRIPTION
# Description of change
The default `singer` backoff uses jitter, but for this case, a constant backoff with no jitter of 5 requests total, each every 4 seconds (20 seconds overall), is appropriate.

This PR also passes the logger into backoff (feature only added in the latest version, requiring a singer-python minor bump to use it) to log the retry attempts properly.

# Manual QA steps
 - Ran through each added backoff decorator with `raise ShortTermLimitExceeded("BOOM")` and saw the desired backoff behavior.
 
# Risks
 - Low, the previous changeset wasn't enough.
 
# Rollback steps
 - revert this branch and bump patch version
