### PR TITLE
Check existence of export file with request before resuming sync

### DIFF
--- a/tap_marketo/client.py
+++ b/tap_marketo/client.py
@@ -258,7 +258,8 @@ class Client:
         endpoint = self.get_bulk_endpoint(stream_type, "file", export_id)
         endpoint_name = "{}_stream".format(stream_type)
         try:
-            result = self.request("GET", endpoint, endpoint_name=endpoint_name, stream=True, headers={"Range": "bytes=0-0"})
+            # Range described here: https://developers.marketo.com/rest-api/bulk-extract/#crayon-5e600bb5f1a53663868461
+            self.request("GET", endpoint, endpoint_name=endpoint_name, stream=True, headers={"Range": "bytes=0-0"})
             return True
         except requests.exceptions.HTTPError as ex:
             if ex.response.status_code == 404:

--- a/tap_marketo/client.py
+++ b/tap_marketo/client.py
@@ -247,7 +247,7 @@ class Client:
         if "result" in result:
             return {r["exportId"]: r for r in result["result"]}
         else:
-            return set()
+            return dict()
 
     def export_file_exists(self, stream_type, export_id, existing_exports):
         if existing_exports.get(export_id, {}).get("status") != "Completed":
@@ -267,8 +267,10 @@ class Client:
             raise
 
     def export_available(self, stream_type, export_id):
+        # NB: Marketo may return that an export is Completed, but the file doesn't exist, so we need to check both.
         existing_exports = self.get_existing_exports(stream_type)
-        return export_id in existing_exports and self.export_file_exists(stream_type, export_id, existing_exports)
+        export_id_exists = export_id in existing_exports
+        return export_id_exists and self.export_file_exists(stream_type, export_id, existing_exports)
 
     def get_export_status(self, stream_type, export_id):
         endpoint = self.get_bulk_endpoint(stream_type, "status", export_id)


### PR DESCRIPTION
# Description of change
It appears that there's a situation where Marketo marks an export as "Completed", but returns a 404 when requesting the file itself. This is an error scenario as far as the tap is concerned.

This PR adjusts the tap's behavior when resuming to check for a 404 when requesting a 0 byte range of the file, and reporting it to the sync code as not existing if that check returns a 404.

# Manual QA steps
 - Ran through a situation with a bookmarked file ID that didn't exist, and ensured it started a new sync.
- Ran through a new sync and ensured that the records were requested and emitted properly
- Ran through end to end with the current code to ensure that it still works
 
# Risks
 - Low, currently the tap will just keep persisting the same state when a bunk `export_id` gets in there.
 
# Rollback steps
 - revert this branch, bump patch version, release new version
