### PR TITLE
bump minor version for tap-marketo to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.0
+  * Enables `leads` stream to work with optional parameter `max_export_days`[#65](https://github.com/singer-io/tap-marketo/pull/65)
+
 ## 2.2.9
   * Fix export availability result around issue where Marketo reports an export as existing, but returns a 404 on the underlying file. [#62](https://github.com/singer-io/tap-marketo/pull/62)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-marketo',
-      version='2.2.9',
+      version='2.3.0',
       description='Singer.io tap for extracting data from the Marketo API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change
bump minor version for tap-marketo to 2.3.0

# Manual QA steps
 - 
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
