### PR TITLE
replace null bytes before writing them to the csv file

### DIFF
--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -136,7 +136,7 @@ def stream_rows(client, stream_type, export_id):
         resp = client.stream_export(stream_type, export_id)
         for chunk in resp.iter_content(chunk_size=1024, decode_unicode=True):
             if chunk:
-                csv_file.write(chunk)
+                csv_file.write(chunk.replace('\0', ''))
 
         singer.log_info("Download completed. Begin streaming rows.")
         csv_file.seek(0)


### PR DESCRIPTION
# Description of change
replace null bytes before writing them to the csv file
https://stitchdata.atlassian.net/browse/SUP-2061


# Manual QA steps
ran with this cloned connection
   before change -> saw NULL bytes exception
   after change -> no error

tested to make sure that we weren't incorrectly removing records that had the string '\0':
>>> txt = 'fkld \0'
>>> txt.replace('\0', '')
'fkld '
>>> txt2 = '\\0'
>>> txt2.replace('\0', '')
'\\0'
^so if there is a string that is literally '\0' on the record, it will come through as '\\0', and when we replace on the string, the '\\0' does not get hit.

# Risks
 - low
 
# Rollback steps
 - revert this branch
