### PR TITLE
Remove null characters before parsing CSVs

### DIFF
--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -140,7 +140,7 @@ def stream_rows(client, stream_type, export_id):
 
         singer.log_info("Download completed. Begin streaming rows.")
         csv_file.seek(0)
-        reader = csv.reader(csv_file, delimiter=',', quotechar='"')
+        reader = csv.reader((line.replace('\0', '') for line in csv_file), delimiter=',', quotechar='"')
         headers = next(reader)
         for line in reader:
             yield dict(zip(headers, line))


### PR DESCRIPTION
# Description of change
Remove null characters before parsing CSVs

# Manual QA steps
 - Ran with a Marketo account that was downloading CSVs with null characters. It was previously unable to parse the CSV. Now it can.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
