### PR TITLE
Remove CR

### DIFF
--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -139,9 +139,8 @@ def stream_rows(client, stream_type, export_id):
         resp = client.stream_export(stream_type, export_id)
         for chunk in resp.iter_content(chunk_size=CHUNK_SIZE_BYTES, decode_unicode=True):
             if chunk:
-                # Replace CR and CRLF
+                # Replace CR
                 chunk = chunk.replace('\r', '')
-                chunk = chunk.replace('\r\n', '')
                 csv_file.write(chunk)
 
         singer.log_info("Download completed. Begin streaming rows.")

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -139,10 +139,19 @@ def stream_rows(client, stream_type, export_id):
         resp = client.stream_export(stream_type, export_id)
         for chunk in resp.iter_content(chunk_size=CHUNK_SIZE_BYTES, decode_unicode=True):
             if chunk:
-                csv_file.write(chunk)
+                # Encode to utf8 bytes
+                byte_str = chunk.encode('utf-8')
+
+                # Replace CR and CRLF
+                byte_str = byte_str.replace(b'\r', b'')
+                byte_str = byte_str.replace(b'\r\n', b'')
+
+                # write the bytes decoded as a string
+                csv_file.write(byte_str.decode('utf-8'))
 
         singer.log_info("Download completed. Begin streaming rows.")
         csv_file.seek(0)
+
         reader = csv.reader((line.replace('\0', '') for line in csv_file), delimiter=',', quotechar='"')
         headers = next(reader)
         for line in reader:

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -139,15 +139,10 @@ def stream_rows(client, stream_type, export_id):
         resp = client.stream_export(stream_type, export_id)
         for chunk in resp.iter_content(chunk_size=CHUNK_SIZE_BYTES, decode_unicode=True):
             if chunk:
-                # Encode to utf8 bytes
-                byte_str = chunk.encode('utf-8')
-
                 # Replace CR and CRLF
-                byte_str = byte_str.replace(b'\r', b'')
-                byte_str = byte_str.replace(b'\r\n', b'')
-
-                # write the bytes decoded as a string
-                csv_file.write(byte_str.decode('utf-8'))
+                chunk = chunk.replace('\r', '')
+                chunk = chunk.replace('\r\n', '')
+                csv_file.write(chunk)
 
         singer.log_info("Download completed. Begin streaming rows.")
         csv_file.seek(0)


### PR DESCRIPTION
# Description of change

Each chunk ~~gets converted to bytes, we find and remove and CR and CRLF's, and then they decode back to a string.~~ replacements for CR and CRLF.

In an effort to change as little as possible, I avoided removing `decode_unicode=True` which would remove the requirement of converting the chunks to bytes. Also there might not be a need to do the bytes conversion.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
