### PR TITLE
Bump version to 2.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.4
+  * Implement Request TimeOut [#78](https://github.com/singer-io/tap-marketo/pull/78)
+
 ## 2.4.3
   * Remove CR characters as CSV chunks are being written [#73](https://github.com/singer-io/tap-marketo/pull/73)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-marketo',
-      version='2.4.3',
+      version='2.4.4',
       description='Singer.io tap for extracting data from the Marketo API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change
Bump version to implement Request Timeout for Marketo

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
