### PR TITLE
add campaignId to activities stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.0
+  * Add campaignId field to activities streams [#82](https://github.com/singer-io/tap-marketo/pull/82)
+
 ## 2.4.4
   * Implement Request TimeOut [#78](https://github.com/singer-io/tap-marketo/pull/78)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-marketo',
-      version='2.4.4',
+      version='2.5.0',
       description='Singer.io tap for extracting data from the Marketo API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_marketo/discover.py
+++ b/tap_marketo/discover.py
@@ -57,15 +57,16 @@ def get_schema_for_type(typ, breadcrumb, mdata, null=False):
 
 
 def get_activity_type_stream(activity):
-    # Activity streams have 6 attributes:
+    # Activity streams have 7 attributes:
     # - marketoGUID
     # - leadId
     # - activityDate
     # - activityTypeId
     # - primaryAttribute
     # - attributes
+    # - campaignId
     #
-    # marketoGUID, leadId, activityDate, and activityTypeId are simple
+    # marketoGUID, leadId, activityDate, activityTypeId, and campaignId are simple
     # fields. primaryAttribute has a name and type which define an
     # automatically included field on the record. Attributes is an array
     # of attribute names and types that become available fields.
@@ -79,7 +80,8 @@ def get_activity_type_stream(activity):
         "marketoGUID": {"type": ["null", "string"]},
         "leadId": {"type": ["null", "integer"]},
         "activityDate": {"type": ["null", "string"], "format": "date-time"},
-        "activityTypeId": {"type": ["null", "integer"]}
+        "activityTypeId": {"type": ["null", "integer"]},
+        "campaignId": {"type": ["null", "integer"]},
     }
 
     for prop in properties:

--- a/tap_marketo/discover.py
+++ b/tap_marketo/discover.py
@@ -85,7 +85,11 @@ def get_activity_type_stream(activity):
     }
 
     for prop in properties:
-        mdata = metadata.write(mdata, ('properties', prop), 'inclusion', 'automatic')
+        # Not every activity will have an associated campaignId, hence the option to select.
+        if prop == "campaignId":
+            mdata = metadata.write(mdata, ('properties', prop), 'inclusion', 'available')
+        else:
+            mdata = metadata.write(mdata, ('properties', prop), 'inclusion', 'automatic')
 
     if "primaryAttribute" in activity:
         properties["primary_attribute_value"] = {"type": ["null", "string"]}

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -17,6 +17,7 @@ BASE_ACTIVITY_FIELDS = [
     "leadId",
     "activityDate",
     "activityTypeId",
+    "campaignId",
 ]
 
 ACTIVITY_FIELDS = BASE_ACTIVITY_FIELDS + [

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -64,6 +64,12 @@ class TestDiscover(unittest.TestCase):
                 },
                 {
                     "metadata" : {
+                        "inclusion": "available"
+                    },
+                    "breadcrumb" : ("properties", 'campaignId')
+                },
+                {
+                    "metadata" : {
                         "inclusion": "automatic"
                     },
                     "breadcrumb" : ("properties", 'primary_attribute_name')
@@ -110,6 +116,9 @@ class TestDiscover(unittest.TestCase):
                     "activityTypeId": {
                         "type": ["null", "integer"],
                     },
+                    "campaignId": {
+                        "type": ["null", "integer"],
+                    },
                     "primary_attribute_name": {
                         "type": ["null", "string"],
                     },
@@ -138,7 +147,7 @@ class TestDiscover(unittest.TestCase):
         self.assertDictEqual(stream, result)
         self.assertEqual(sorted(result_metadata, key=lambda x: x['breadcrumb']),
                          sorted(stream_metadata, key=lambda x: x['breadcrumb']))
-        self.assertEqual(10, len(result_metadata))
+        self.assertEqual(11, len(result_metadata))
         self.assertEqual(7,automatic_count)
 
     def test_discover_leads(self):


### PR DESCRIPTION
# Description of change
marketo bulk api returns `campaignId`.

---
https://developers.marketo.com/rest-api/bulk-extract/bulk-activity-extract/

Optional array of strings containing field values.  The listed fields will be included in the exported file.  By default, the following fields are returned:
  - marketoGUID
  - leadId
  - activityDate
  - activityTypeId
  - campaignId
  - primaryAttributeValueId
  - primaryAttributeValue
  - attributes
---
This change adds it to activities streams as `'inclusion', 'available'`.

# Manual QA steps
 - Verified campaignId respects `inclusion`
 
# Risks
 - Low. This only adds the option to select campaignId.
 
# Rollback steps
 - revert this branch

Co-authored-by: leslievandemark <lvandemark@talend.com>