### PR TITLE
tap-marketo - static schema for leads if required by users to support…

### DIFF
--- a/tap_marketo/discover.py
+++ b/tap_marketo/discover.py
@@ -141,6 +141,11 @@ def discover_activities(client):
 
 
 def discover_leads(client):
+    root = os.path.dirname(os.path.realpath(__file__))
+    path = os.path.join(root, 'schemas/{}.json'.format('leads'))
+    if os.path.isfile(path):
+        discovered_schema = discover_catalog('leads', LEAD_REQUIRED_FIELDS)
+        return discovered_schema
     # http://developers.marketo.com/rest-api/lead-database/leads/#describe
     endpoint = "rest/v1/leads/describe.json"
     data = client.request("GET", endpoint, endpoint_name="leads_discover")


### PR DESCRIPTION
… 1500 mb limit

# Description of change
Adding availability to have a static schema for leads object if required by the user, our Marketo lead objects are too big and  we are facing 1500 mb limitation while loading our data even for a day. To handle this we have added functionality to enable static schema for leads object allowing users to select and pull only the fields they need for analysis

# Manual QA steps
  Tested loads for both with and without leads schema file, both working fine
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
