### PR TITLE
add backoff for job queue full errors

### DIFF
--- a/tap_marketo/__init__.py
+++ b/tap_marketo/__init__.py
@@ -8,7 +8,7 @@ from singer import bookmarks
 
 from tap_marketo.client import Client
 from tap_marketo.discover import discover
-from tap_marketo.sync import sync, determine_replication_key
+import tap_marketo.sync as s 
 from singer.bookmarks import (
     get_bookmark,
     write_bookmark,
@@ -42,7 +42,7 @@ def validate_state(config, catalog, state):
                     set_currently_syncing(state, None)
                 break
 
-        replication_key = determine_replication_key(stream['tap_stream_id'])
+        replication_key = s.determine_replication_key(stream['tap_stream_id'])
         if not replication_key:
             continue
 
@@ -66,7 +66,7 @@ def _main(config, properties, state, discover_mode=False):
         discover(client)
     elif properties:
         state = validate_state(config, properties, state)
-        sync(client, properties, config, state)
+        s.sync(client, properties, config, state)
 
 
 def main():


### PR DESCRIPTION
# Description of change

* adds test for backoff strategy
* adds error handling (backoff strategy) for `1029, Too many job (10) in queue` as described [here](https://developers.marketo.com/rest-api/bulk-extract/):

> ## Queue
>
> The bulk extract APIs use a job queue (shared between leads, activities, program members, and custom objects).  Extract jobs must first be created, and then enqueued by calling Create Export Lead/Activity/Program Member Job and Enqueue Export Lead/Activity/Program Member Job endpoints.  Once enqueued, the jobs are pulled from the queue and started when computing resources become available.
>
> The maximimum number of jobs in the queue is 10.  If you try to enqueue a job when the queue is full, the Enqueue Export Job endpoint will return an error “1029, Too many jobs in queue”.  A maximum of 2 jobs can run concurrently (status is “Processing”).

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
