### PR TITLE
Log the corona warning only for Leads and activities_* streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.6.1
+  * Log Corona warning only if the leads and activities_* stream are selected [#94](https://github.com/singer-io/tap-marketo/pull/94)
+
 ## 2.6.0
   * Updates to run on python 3.11 [#91](https://github.com/singer-io/tap-marketo/pull/91)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-marketo',
-      version='2.6.0',
+      version='2.6.1',
       description='Singer.io tap for extracting data from the Marketo API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -512,6 +512,5 @@ def sync(client, catalog, config, state):
     # If Corona is not supported, log a warning near the end of the tap
     # log with instructions on how to get Corona supported.
     singer.log_info("Finished sync.")
-    if corona_warning_flag:
-        if not client.use_corona:
+    if corona_warning_flag and not client.use_corona:
             singer.log_warning(NO_CORONA_WARNING)

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -461,6 +461,7 @@ def sync(client, catalog, config, state):
     else:
         singer.log_info("Starting sync")
 
+    corona_warning_flag = False
     for stream in catalog["streams"]:
         # Skip unselected streams.
         mdata = metadata.to_map(stream['metadata'])
@@ -487,8 +488,10 @@ def sync(client, catalog, config, state):
             state, record_count = sync_activity_types(client, state, stream)
         elif stream["tap_stream_id"] == "leads":
             state, record_count = sync_leads(client, state, stream, config)
+            corona_warning_flag = True
         elif stream["tap_stream_id"].startswith("activities_"):
             state, record_count = sync_activities(client, state, stream, config)
+            corona_warning_flag = True
         elif stream["tap_stream_id"] in ["campaigns", "lists"]:
             state, record_count = sync_paginated(client, state, stream)
         elif stream["tap_stream_id"] == "programs":
@@ -509,5 +512,5 @@ def sync(client, catalog, config, state):
     # If Corona is not supported, log a warning near the end of the tap
     # log with instructions on how to get Corona supported.
     singer.log_info("Finished sync.")
-    if not client.use_corona:
+    if not client.use_corona and corona_warning_flag:
         singer.log_warning(NO_CORONA_WARNING)

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -512,5 +512,6 @@ def sync(client, catalog, config, state):
     # If Corona is not supported, log a warning near the end of the tap
     # log with instructions on how to get Corona supported.
     singer.log_info("Finished sync.")
-    if not client.use_corona and corona_warning_flag:
-        singer.log_warning(NO_CORONA_WARNING)
+    if corona_warning_flag:
+        if not client.use_corona:
+            singer.log_warning(NO_CORONA_WARNING)


### PR DESCRIPTION
# Description of change
The Mambu Bulk API managed through the Corona application, is designed to handle large volumes of data efficiently. The stream - Leads and activities_* only support bulk API extract. Therefore, if the streams **Leads** and **activities_*** are not selected then bypass the warning for the corona as it removes the occurrence of the below error post-sync.

`Marketo API returned error(s): [{'code': '1029', 'message': 'Export daily quota 500MB exceeded.'}]. Data can resume replicating at midnight central time. Read more about Marketo Bulk API limits here: http://developers.marketo.com/rest-api/bulk-extract/#limits`

# Manual QA steps
 - Performed PR-alpha on the connection
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
