### PR TITLE
Move test dependencies to setup.py extras_require

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: |
             virtualenv -p python3 ~/.virtualenvs/tap-marketo
             source ~/.virtualenvs/tap-marketo/bin/activate
-            pip install .
+            pip install .[test]
             pip install pylint
       - run:
           name: 'Pylint'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.6.2
+  * Move test dependencies to `extras_require` and pin them [#96](https://github.com/singer-io/tap-marketo/pull/96)
+
 ## 2.6.1
   * Log Corona warning only if the leads and activities_* stream are selected [#94](https://github.com/singer-io/tap-marketo/pull/94)
 

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,15 @@ setup(name='tap-marketo',
           'singer-python==6.0.0',
           'requests==2.31.0',
           'pendulum==1.2.0',
-          'freezegun>=0.3.9',
-          'requests_mock>=1.3.0',
           'backoff==2.2.1',
       ],
       extras_require={
           'dev': [
-              'ipdb==0.11'
+              'ipdb',
+          ],
+          'test': [
+              'freezegun==1.5.1',
+              'requests_mock==1.12.1',
           ]
       },
       entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-marketo',
-      version='2.6.1',
+      version='2.6.2',
       description='Singer.io tap for extracting data from the Marketo API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change
- Test dependencies will no longer be installed by default
- Updates circleci config to specifically install test dependencies

# Manual QA steps
 - N/A
 
# Risks
 - Low. No functional changes have been made and dependencies are pinned to the same version they are currently running.
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
