### PR TITLE
Update testing infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,13 @@ jobs:
           name: 'Setup'
           command: |
             uv venv --python=3.11 /usr/local/share/virtualenvs/tap-marketo
-            source /usr/local/share/tap-marketo/bin/activate
+            source /usr/local/share/virtualenvs/tap-marketo/bin/activate
             uv pip install .[test]
             uv pip install pylint
       - run:
           name: 'Pylint'
           command: |
-            source /usr/local/share/tap-marketo/bin/activate
+            source /usr/local/share/virtualenvs/tap-marketo/bin/activate
             pylint tap_marketo -d C,R,W
       - run:
           name: 'JSON Validator'
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: 'Unit Tests'
           command: |
-            source /usr/local/share/tap-marketo/bin/activate
+            source /usr/local/share/virtualenvs/tap-marketo/bin/activate
             uv pip install nose2 parameterized nose2[coverage_plugin]>=0.6.5
             nose2 --with-coverage -v -s tests
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,14 @@ jobs:
       - run:
           name: 'Setup'
           command: |
-            uv venv --python=3.11 ~/.virtualenvs/tap-marketo
-            source ~/.virtualenvs/tap-marketo/bin/activate
+            uv venv --python=3.11 /usr/local/share/virtualenvs/tap-marketo
+            source /usr/local/share/tap-marketo/bin/activate
             pip install .[test]
             pip install pylint
       - run:
           name: 'Pylint'
           command: |
-            source ~/.virtualenvs/tap-marketo/bin/activate
+            source /usr/local/share/tap-marketo/bin/activate
             pylint tap_marketo -d C,R,W
       - run:
           name: 'JSON Validator'
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: 'Unit Tests'
           command: |
-            source ~/.virtualenvs/tap-marketo/bin/activate
+            source /usr/local/share/tap-marketo/bin/activate
             pip install nose2 parameterized nose2[coverage_plugin]>=0.6.5
             nose2 --with-coverage -v -s tests
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ jobs:
           command: |
             uv venv --python=3.11 /usr/local/share/virtualenvs/tap-marketo
             source /usr/local/share/tap-marketo/bin/activate
-            pip install .[test]
-            pip install pylint
+            uv pip install .[test]
+            uv pip install pylint
       - run:
           name: 'Pylint'
           command: |
@@ -26,7 +26,7 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/tap-marketo/bin/activate
-            pip install nose2 parameterized nose2[coverage_plugin]>=0.6.5
+            uv pip install nose2 parameterized nose2[coverage_plugin]>=0.6.5
             nose2 --with-coverage -v -s tests
       - store_test_results:
           path: test_output/report.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup'
           command: |
-            virtualenv -p python3 ~/.virtualenvs/tap-marketo
+            uv venv --python=3.11 ~/.virtualenvs/tap-marketo
             source ~/.virtualenvs/tap-marketo/bin/activate
             pip install .[test]
             pip install pylint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup'
           command: |
-            uv venv --python=3.11 /usr/local/share/virtualenvs/tap-marketo
+            uv venv --python 3.11 /usr/local/share/virtualenvs/tap-marketo
             source /usr/local/share/virtualenvs/tap-marketo/bin/activate
             uv pip install .[test]
             uv pip install pylint


### PR DESCRIPTION
This PR updates the CircleCI config to use `uv` to create and manage virtualenvs and python dependencies