### PR TITLE
[SAC-28859] - `replication_key` and `forced_replication_method` addition in catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.6.5
+  * Add `valid-replication-keys` and `forced-replication-method` fields to catalog metadata for better incremental replication control [#104](https://github.com/singer-io/tap-marketo/pull/104)
+
 ## 2.6.4
   * Bump dependency versions for twistlock compliance [#99](https://github.com/singer-io/tap-marketo/pull/99)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.6.5
+## 2.7.0
   * Add `valid-replication-keys` and `forced-replication-method` fields to catalog metadata for better incremental replication control [#104](https://github.com/singer-io/tap-marketo/pull/104)
 
 ## 2.6.4

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-marketo',
-      version='2.6.4',
+      version='2.6.5',
       description='Singer.io tap for extracting data from the Marketo API',
       author='Stitch',
       url='http://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-marketo',
-      version='2.6.5',
+      version='2.7.0',
       description='Singer.io tap for extracting data from the Marketo API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_marketo/discover.py
+++ b/tap_marketo/discover.py
@@ -4,6 +4,8 @@ import sys
 
 import singer
 from singer import metadata
+from tap_marketo.sync import determine_replication_key
+
 
 STRING_TYPES = [
     'string',
@@ -189,6 +191,10 @@ def discover_catalog(name, automatic_inclusion, **kwargs):
 
     with open(path, "r") as f:
         discovered_schema = json.load(f)
+
+        valid_replication_keys=determine_replication_key(discovered_schema['tap_stream_id'])
+        if valid_replication_keys is not None:
+            mdata = metadata.write(mdata, (), 'valid-replication-keys', valid_replication_keys)
 
         for field in discovered_schema["schema"]["properties"]:
             if field in automatic_inclusion:

--- a/tap_marketo/discover.py
+++ b/tap_marketo/discover.py
@@ -58,7 +58,7 @@ def get_schema_for_type(typ, breadcrumb, mdata, null=False):
     return rtn, mdata
 
 
-def metadata_replication_key_and_method(mdata, valid_replication_keys):
+def set_replication_metadata(mdata, valid_replication_keys):
     mdata = metadata.write(mdata, (), 'forced-replication-method', 'FULL_TABLE')
     if valid_replication_keys:
         mdata = metadata.write(mdata, (), 'forced-replication-method', 'INCREMENTAL')
@@ -129,7 +129,7 @@ def get_activity_type_stream(activity):
 
     # The activities steams use "marketoGUID" as the key_properties
     mdata = metadata.write(mdata, (), 'table-key-properties', ['marketoGUID'])
-    mdata = metadata_replication_key_and_method(
+    mdata = set_replication_metadata(
         mdata,
         valid_replication_keys=determine_replication_key('activities')
     )
@@ -181,7 +181,7 @@ def discover_leads(client):
 
     # The leads steam uses "id" as the key_properties
     mdata = metadata.write(mdata, (), 'table-key-properties', ['id'])
-    mdata = metadata_replication_key_and_method(
+    mdata = set_replication_metadata(
         mdata,
         valid_replication_keys=determine_replication_key('leads')
     )
@@ -218,7 +218,7 @@ def discover_catalog(name, automatic_inclusion, **kwargs):
 
         # The steams using discover_catalog all use "id" as the key_properties
         mdata = metadata.write(mdata, (), 'table-key-properties', ['id'])
-        mdata = metadata_replication_key_and_method(
+        mdata = set_replication_metadata(
             mdata,
             determine_replication_key(discovered_schema['tap_stream_id'])
         )

--- a/tap_marketo/discover.py
+++ b/tap_marketo/discover.py
@@ -58,6 +58,14 @@ def get_schema_for_type(typ, breadcrumb, mdata, null=False):
     return rtn, mdata
 
 
+def metadata_replication_key_and_method(mdata, valid_replication_keys):
+    mdata = metadata.write(mdata, (), 'forced-replication-method', 'FULL_TABLE')
+    if valid_replication_keys:
+        mdata = metadata.write(mdata, (), 'forced-replication-method', 'INCREMENTAL')
+        mdata = metadata.write(mdata, (), 'valid-replication-keys', valid_replication_keys)
+    return mdata
+
+
 def get_activity_type_stream(activity):
     # Activity streams have 7 attributes:
     # - marketoGUID
@@ -121,6 +129,10 @@ def get_activity_type_stream(activity):
 
     # The activities steams use "marketoGUID" as the key_properties
     mdata = metadata.write(mdata, (), 'table-key-properties', ['marketoGUID'])
+    mdata = metadata_replication_key_and_method(
+        mdata,
+        valid_replication_keys=determine_replication_key('activities')
+    )
 
     return {
         "tap_stream_id": tap_stream_id,
@@ -169,6 +181,10 @@ def discover_leads(client):
 
     # The leads steam uses "id" as the key_properties
     mdata = metadata.write(mdata, (), 'table-key-properties', ['id'])
+    mdata = metadata_replication_key_and_method(
+        mdata,
+        valid_replication_keys=determine_replication_key('leads')
+    )
 
     return {
         "tap_stream_id": "leads",
@@ -192,10 +208,6 @@ def discover_catalog(name, automatic_inclusion, **kwargs):
     with open(path, "r") as f:
         discovered_schema = json.load(f)
 
-        valid_replication_keys=determine_replication_key(discovered_schema['tap_stream_id'])
-        if valid_replication_keys is not None:
-            mdata = metadata.write(mdata, (), 'valid-replication-keys', valid_replication_keys)
-
         for field in discovered_schema["schema"]["properties"]:
             if field in automatic_inclusion:
                 mdata = metadata.write(mdata, ('properties', field), 'inclusion', 'automatic')
@@ -206,6 +218,10 @@ def discover_catalog(name, automatic_inclusion, **kwargs):
 
         # The steams using discover_catalog all use "id" as the key_properties
         mdata = metadata.write(mdata, (), 'table-key-properties', ['id'])
+        mdata = metadata_replication_key_and_method(
+            mdata,
+            determine_replication_key(discovered_schema['tap_stream_id'])
+        )
 
         discovered_schema["metadata"] = metadata.to_list(mdata)
         return discovered_schema

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -2,9 +2,11 @@ import unittest
 
 import pendulum
 import requests_mock
+from singer import metadata
 
 from tap_marketo.client import Client
 from tap_marketo.discover import *
+from tap_marketo.sync import determine_replication_key
 
 
 class TestDiscover(unittest.TestCase):
@@ -188,9 +190,130 @@ class TestDiscover(unittest.TestCase):
             result = discover_leads(client)
             metadata = result.pop("metadata")
             automatic_count = 0
+            root_metadata = None
             for mdata in metadata:
                 if mdata.get('metadata', {}).get('inclusion') == 'automatic':
                     automatic_count += 1
+                if mdata['breadcrumb'] == ():
+                    root_metadata = mdata['metadata']
+            
             self.assertDictEqual(stream, result)
             self.assertEqual(3,len(metadata))
             self.assertEqual(1,automatic_count)
+            # Test new replication metadata
+            self.assertEqual(root_metadata['forced-replication-method'], 'INCREMENTAL')
+            self.assertEqual(root_metadata['valid-replication-keys'], 'updatedAt')
+
+    def test_discover_catalog_campaigns(self):
+        result = discover_catalog("campaigns", CAMPAIGNS_AUTOMATIC_INCLUSION)
+        metadata = result["metadata"]
+        
+        # Find root metadata
+        root_metadata = None
+        for mdata in metadata:
+            if mdata['breadcrumb'] == ():
+                root_metadata = mdata['metadata']
+                break
+        
+        # Test basic properties
+        self.assertEqual(result["tap_stream_id"], "campaigns")
+        self.assertEqual(result["key_properties"], ["id"])
+        
+        # Test new replication metadata
+        self.assertEqual(root_metadata['forced-replication-method'], 'INCREMENTAL')
+        self.assertEqual(root_metadata['valid-replication-keys'], 'updatedAt')
+        self.assertEqual(root_metadata['table-key-properties'], ['id'])
+
+    def test_discover_catalog_activity_types(self):
+        result = discover_catalog("activity_types", ACTIVITY_TYPES_AUTOMATIC_INCLUSION, unsupported=ACTIVITY_TYPES_UNSUPPORTED)
+        metadata = result["metadata"]
+        
+        # Find root metadata
+        root_metadata = None
+        for mdata in metadata:
+            if mdata['breadcrumb'] == ():
+                root_metadata = mdata['metadata']
+                break
+        
+        # Test basic properties
+        self.assertEqual(result["tap_stream_id"], "activity_types")
+        self.assertEqual(result["key_properties"], ["id"])
+        
+        # Test new replication metadata - activity_types should be FULL_TABLE with no valid replication keys
+        self.assertEqual(root_metadata['forced-replication-method'], 'FULL_TABLE')
+        self.assertNotIn('valid-replication-keys', root_metadata)
+        self.assertEqual(root_metadata['table-key-properties'], ['id'])
+
+    def test_set_replication_metadata(self):
+        # Test with no valid replication keys (FULL_TABLE)
+        mdata = metadata.new()
+        result = set_replication_metadata(mdata, None)
+        result_list = metadata.to_list(result)
+        result_dict = metadata.to_map(result_list)
+        
+        self.assertEqual(result_dict[()]['forced-replication-method'], 'FULL_TABLE')
+        self.assertNotIn('valid-replication-keys', result_dict[()])
+        
+        # Test with valid replication keys (INCREMENTAL)
+        mdata = metadata.new()
+        result = set_replication_metadata(mdata, 'updatedAt')
+        result_list = metadata.to_list(result)
+        result_dict = metadata.to_map(result_list)
+        
+        self.assertEqual(result_dict[()]['forced-replication-method'], 'INCREMENTAL')
+        self.assertEqual(result_dict[()]['valid-replication-keys'], 'updatedAt')
+
+    def test_determine_replication_key(self):
+        # Test activity streams
+        self.assertEqual(determine_replication_key('activities_visit_webpage'), 'activityDate')
+        self.assertEqual(determine_replication_key('activities_email_sent'), 'activityDate')
+        
+        # Test other streams
+        self.assertEqual(determine_replication_key('leads'), 'updatedAt')
+        self.assertEqual(determine_replication_key('campaigns'), 'updatedAt')
+        self.assertEqual(determine_replication_key('lists'), 'updatedAt')
+        self.assertEqual(determine_replication_key('programs'), 'updatedAt')
+        
+        # Test streams with no replication key
+        self.assertIsNone(determine_replication_key('activity_types'))
+        self.assertIsNone(determine_replication_key('unknown_stream'))
+
+    def test_discover_catalog_lists(self):
+        result = discover_catalog("lists", LISTS_AUTOMATIC_INCLUSION)
+        metadata = result["metadata"]
+        
+        # Find root metadata
+        root_metadata = None
+        for mdata in metadata:
+            if mdata['breadcrumb'] == ():
+                root_metadata = mdata['metadata']
+                break
+        
+        # Test basic properties
+        self.assertEqual(result["tap_stream_id"], "lists")
+        self.assertEqual(result["key_properties"], ["id"])
+        
+        # Test new replication metadata
+        self.assertEqual(root_metadata['forced-replication-method'], 'INCREMENTAL')
+        self.assertEqual(root_metadata['valid-replication-keys'], 'updatedAt')
+        self.assertEqual(root_metadata['table-key-properties'], ['id'])
+
+    def test_discover_catalog_programs(self):
+        result = discover_catalog("programs", PROGRAMS_AUTOMATIC_INCLUSION)
+        metadata = result["metadata"]
+        
+        # Find root metadata
+        root_metadata = None
+        for mdata in metadata:
+            if mdata['breadcrumb'] == ():
+                root_metadata = mdata['metadata']
+                break
+        
+        # Test basic properties
+        self.assertEqual(result["tap_stream_id"], "programs")
+        self.assertEqual(result["key_properties"], ["id"])
+        
+        # Test new replication metadata
+        self.assertEqual(root_metadata['forced-replication-method'], 'INCREMENTAL')
+        self.assertEqual(root_metadata['valid-replication-keys'], 'updatedAt')
+        self.assertEqual(root_metadata['table-key-properties'], ['id'])

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -37,7 +37,8 @@ class TestDiscover(unittest.TestCase):
                 {'breadcrumb': (),
                  'metadata': {'table-key-properties': ['marketoGUID'],
                               'marketo.activity-id': 1,
-                              'marketo.primary-attribute-name': 'webpage_id'}},
+                              'marketo.primary-attribute-name': 'webpage_id',
+                              'forced-replication-method': 'FULL_TABLE'}},
                 {
                     "metadata" : {
                         "inclusion": "automatic"


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-28859

> **Add `replication_key` and `forced_replication_method` fields to the catalog**
> This change updates the tap-marketo catalog to include two new metadata fields  `replication_key` and `forced_replication_method` for streams, enabling better control over incremental replication strategies.

 
# Rollback steps
 - revert this branch
