### PR TITLE
Adding ingestion streams for usage and errors to support API health

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,10 @@ setup(name='tap-marketo',
               "activity_types.json",
               "campaigns.json",
               "programs.json",
+              "usage.json",
+              "usage_last7days.json",
+              "errors.json",
+              "errors_last7days.json"
           ]
       },
       include_package_data=True,

--- a/tap_marketo/discover.py
+++ b/tap_marketo/discover.py
@@ -23,6 +23,8 @@ ACTIVITY_TYPES_UNSUPPORTED = frozenset(["attributes"])
 LISTS_AUTOMATIC_INCLUSION = frozenset(["id", "name", "createdAt", "updatedAt"])
 PROGRAMS_AUTOMATIC_INCLUSION = frozenset(["id", "createdAt", "updatedAt"])
 CAMPAIGNS_AUTOMATIC_INCLUSION = frozenset(["id", "createdAt", "updatedAt"])
+ERRORS_AUTOMATIC_INCLUSION = frozenset(["date", "errors"])
+USAGE_AUTOMATIC_INCLUSION = frozenset(["date", "total"])
 
 LEAD_REQUIRED_FIELDS = frozenset(["id", "updatedAt", "createdAt"])
 
@@ -235,5 +237,7 @@ def discover(client):
     streams.append(discover_catalog("campaigns", CAMPAIGNS_AUTOMATIC_INCLUSION))
     streams.append(discover_catalog("lists", LISTS_AUTOMATIC_INCLUSION))
     streams.append(discover_catalog("programs", PROGRAMS_AUTOMATIC_INCLUSION))
+    streams.append(discover_catalog("usage", USAGE_AUTOMATIC_INCLUSION))
+    streams.append(discover_catalog("errors", ERRORS_AUTOMATIC_INCLUSION))
     json.dump({"streams": streams}, sys.stdout, indent=2)
     singer.log_info("Finished discover")

--- a/tap_marketo/discover.py
+++ b/tap_marketo/discover.py
@@ -239,5 +239,7 @@ def discover(client):
     streams.append(discover_catalog("programs", PROGRAMS_AUTOMATIC_INCLUSION))
     streams.append(discover_catalog("usage", USAGE_AUTOMATIC_INCLUSION))
     streams.append(discover_catalog("errors", ERRORS_AUTOMATIC_INCLUSION))
+    streams.append(discover_catalog("usage_last7days", USAGE_AUTOMATIC_INCLUSION))
+    streams.append(discover_catalog("errors_last7days", ERRORS_AUTOMATIC_INCLUSION))
     json.dump({"streams": streams}, sys.stdout, indent=2)
     singer.log_info("Finished discover")

--- a/tap_marketo/discover.py
+++ b/tap_marketo/discover.py
@@ -23,7 +23,7 @@ ACTIVITY_TYPES_UNSUPPORTED = frozenset(["attributes"])
 LISTS_AUTOMATIC_INCLUSION = frozenset(["id", "name", "createdAt", "updatedAt"])
 PROGRAMS_AUTOMATIC_INCLUSION = frozenset(["id", "createdAt", "updatedAt"])
 CAMPAIGNS_AUTOMATIC_INCLUSION = frozenset(["id", "createdAt", "updatedAt"])
-ERRORS_AUTOMATIC_INCLUSION = frozenset(["date", "errors"])
+ERRORS_AUTOMATIC_INCLUSION = frozenset(["date", "total"])
 USAGE_AUTOMATIC_INCLUSION = frozenset(["date", "total"])
 
 LEAD_REQUIRED_FIELDS = frozenset(["id", "updatedAt", "createdAt"])

--- a/tap_marketo/schemas/errors.json
+++ b/tap_marketo/schemas/errors.json
@@ -1,0 +1,29 @@
+{
+  "tap_stream_id": "errors",
+  "stream": "errors",
+  "key_properties": ["date"],
+  "schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "date": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "errors": {
+        "type": ["array", "null"],
+        "items": {
+          "type": "object",
+          "properties": {
+            "count": {
+              "type": ["null", "integer"]
+            },
+            "errorCode": {
+              "type": ["null", "string"]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tap_marketo/schemas/errors_last7days.json
+++ b/tap_marketo/schemas/errors_last7days.json
@@ -1,6 +1,6 @@
 {
-  "tap_stream_id": "errors",
-  "stream": "errors",
+  "tap_stream_id": "errors_last7days",
+  "stream": "errors_last7days",
   "key_properties": ["date"],
   "schema": {
     "type": "object",

--- a/tap_marketo/schemas/usage.json
+++ b/tap_marketo/schemas/usage.json
@@ -1,0 +1,32 @@
+{
+  "tap_stream_id": "usage",
+  "stream": "usage",
+  "key_properties": ["date"],
+  "schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "date": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "total": {
+        "type": "integer"
+      },
+      "users": {
+        "type": ["array", "null"],
+        "items": {
+          "type": "object",
+          "properties": {
+            "count": {
+              "type": ["null", "integer"]
+            },
+            "userId": {
+              "type": ["null", "string"]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tap_marketo/schemas/usage_last7days.json
+++ b/tap_marketo/schemas/usage_last7days.json
@@ -1,6 +1,6 @@
 {
-  "tap_stream_id": "errors",
-  "stream": "errors",
+  "tap_stream_id": "usage_last7days",
+  "stream": "usage_last7days",
   "key_properties": ["date"],
   "schema": {
     "type": "object",
@@ -13,7 +13,7 @@
       "total": {
         "type": "integer"
       },
-      "errors": {
+      "users": {
         "type": ["array", "null"],
         "items": {
           "type": "object",
@@ -21,7 +21,7 @@
             "count": {
               "type": ["null", "integer"]
             },
-            "errorCode": {
+            "userId": {
               "type": ["null", "string"]
             }
           }

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -37,6 +37,10 @@ def determine_replication_key(tap_stream_id):
         return 'updatedAt'
     elif tap_stream_id == 'campaigns':
         return 'updatedAt'
+    elif tap_stream_id == 'errors':
+        return 'date'
+    elif tap_stream_id == 'usage':
+        return 'date'
     elif tap_stream_id == 'programs':
         return 'updatedAt'
     else:
@@ -376,7 +380,7 @@ def sync_programs(client, state, stream):
     return state, record_count
 
 
-def sync_paginated(client, state, stream):
+def sync_paginated(client, state, stream, endpoint_prefix=""):
     # http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Campaigns/getCampaignsUsingGET
     # http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Static_Lists/getListsUsingGET
     #
@@ -388,7 +392,7 @@ def sync_paginated(client, state, stream):
     singer.write_schema(stream["tap_stream_id"], stream["schema"], stream["key_properties"], bookmark_properties=[replication_key])
     start_date = bookmarks.get_bookmark(state, stream["tap_stream_id"], replication_key)
     params = {"batchSize": 300}
-    endpoint = "rest/v1/{}.json".format(stream["tap_stream_id"])
+    endpoint = "rest/v1/{}{}.json".format(endpoint_prefix, stream["tap_stream_id"])
 
     # Paginated requests use paging tokens for retrieving the next page
     # of results. These tokens are stored in the state for resuming
@@ -494,6 +498,8 @@ def sync(client, catalog, config, state):
             corona_warning_flag = True
         elif stream["tap_stream_id"] in ["campaigns", "lists"]:
             state, record_count = sync_paginated(client, state, stream)
+        elif stream["tap_stream_id"] in ["errors", "usage"]:
+            state, record_count = sync_paginated(client, state, stream, endpoint_prefix="stats/")
         elif stream["tap_stream_id"] == "programs":
             state, record_count = sync_programs(client, state, stream)
         else:

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -39,7 +39,11 @@ def determine_replication_key(tap_stream_id):
         return 'updatedAt'
     elif tap_stream_id == 'errors':
         return 'date'
+    elif tap_stream_id == 'errors_last7days':
+        return 'date'
     elif tap_stream_id == 'usage':
+        return 'date'
+    elif tap_stream_id == 'usage_last7days':
         return 'date'
     elif tap_stream_id == 'programs':
         return 'updatedAt'
@@ -392,7 +396,10 @@ def sync_paginated(client, state, stream, endpoint_prefix=""):
     singer.write_schema(stream["tap_stream_id"], stream["schema"], stream["key_properties"], bookmark_properties=[replication_key])
     start_date = bookmarks.get_bookmark(state, stream["tap_stream_id"], replication_key)
     params = {"batchSize": 300}
-    endpoint = "rest/v1/{}{}.json".format(endpoint_prefix, stream["tap_stream_id"])
+    requested_field = stream["tap_stream_id"]
+    if "_" in stream["tap_stream_id"]:
+        requested_field = stream["tap_stream_id"].replace("_", "/")
+    endpoint = "rest/v1/{}{}.json".format(endpoint_prefix, requested_field)
 
     # Paginated requests use paging tokens for retrieving the next page
     # of results. These tokens are stored in the state for resuming
@@ -498,7 +505,7 @@ def sync(client, catalog, config, state):
             corona_warning_flag = True
         elif stream["tap_stream_id"] in ["campaigns", "lists"]:
             state, record_count = sync_paginated(client, state, stream)
-        elif stream["tap_stream_id"] in ["errors", "usage"]:
+        elif stream["tap_stream_id"] in ["errors", "usage", "errors_last7days", "usage_last7days"]:
             state, record_count = sync_paginated(client, state, stream, endpoint_prefix="stats/")
         elif stream["tap_stream_id"] == "programs":
             state, record_count = sync_programs(client, state, stream)


### PR DESCRIPTION
# Description of change
Within this PR, it adds streams for `usage` and `errors`.  These streams enable the user of the tap to understand issues that have occurred historically in the API.

# Manual QA steps
Validated the code change with the real Marketo API: 
```
$>  meltano invoke tap-marketo
INFO usage_last7days: starting sync
....
INFO GET: https://localhost:8080/rest/v1/stats/errors/last7days.json?batchSize=300
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.14824628829956055, "tags": {"endpoint": "usage_last7days", "status": "succeeded"}}
{"type": "RECORD", "stream": "usage_last7days", "record": {"date": "2025-11-06T00:00:00+00:00", "total": 12829, "users": [{"userId": "****", "count": 214}, {"userId": "***", "count": 869}, {"userId": "****", "count": 1272}, {"userId": "***", "count": 15}, {"userId": "****", "count": 148}, {"userId": "****, "count": 2861}, {"userId": "***", "count": 857}, {"userId": "***", "count": 24}, {"userId": "***", "count": 741}, {"userId": "****", "count": 5551}, {"userId": "****", "count": 268}, {"userId": "***", "count": 9}]}, "time_extracted": "2025-11-06T15:13:33.001322Z"}
....
INFO usage_last7days: finished sync

```
```
$> meltano invoke tap-marketo 
INFO GET: https://localhost:8080/rest/v1/stats/errors/last7days.json?batchSize=300
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.14680838584899902, "tags": {"endpoint": "errors_last7days", "status": "succeeded"}}
{"type": "RECORD", "stream": "errors_last7days", "record": {"date": "2025-11-06T00:00:00+00:00", "total": 127, "errors": [{"errorCode": "1019", "count": 46}, {"errorCode": "1003", "count": 81}]}, "time_extracted": "2025-11-06T15:13:33.151823Z"}
{"type": "RECORD", "stream": "errors_last7days", "record": {"date": "2025-11-05T00:00:00+00:00", "total": 297, "errors": [{"errorCode": "610", "count": 10}, {"errorCode": "1029", "count": 2}, {"errorCode": "1003", "count": 231}, {"errorCode": "1019", "count": 52}, {"errorCode": "606", "count": 2}]}, "time_extracted": "2025-11-06T15:13:33.151823Z"}
{"type": "RECORD", "stream": "errors_last7days", "record": {"date": "2025-11-04T00:00:00+00:00", "total": 283, "errors": [{"errorCode": "1019", "count": 54}, {"errorCode": "610", "count": 10}, {"errorCode": "1003", "count": 216}, {"errorCode": "1029", "count": 2}, {"errorCode": "606", "count": 1}]}, "time_extracted": "2025-11-06T15:13:33.151823Z"}
{"type": "RECORD", "stream": "errors_last7days", "record": {"date": "2025-11-03T00:00:00+00:00", "total": 247, "errors": [{"errorCode": "1003", "count": 166}, {"errorCode": "610", "count": 10}, {"errorCode": "1029", "count": 4}, {"errorCode": "1004", "count": 3}, {"errorCode": "1019", "count": 53}, {"errorCode": "606", "count": 11}]}, "time_extracted": "2025-11-06T15:13:33.151823Z"}
{"type": "RECORD", "stream": "errors_last7days", "record": {"date": "2025-11-02T00:00:00+00:00", "total": 176, "errors": [{"errorCode": "1004", "count": 3}, {"errorCode": "1003", "count": 169}, {"errorCode": "1029", "count": 4}]}, "time_extracted": "2025-11-06T15:13:33.151823Z"}
{"type": "RECORD", "stream": "errors_last7days", "record": {"date": "2025-11-01T00:00:00+00:00", "total": 520, "errors": [{"errorCode": "1029", "count": 2}, {"errorCode": "610", "count": 10}, {"errorCode": "1003", "count": 154}, {"errorCode": "1019", "count": 354}]}, "time_extracted": "2025-11-06T15:13:33.151823Z"}
{"type": "RECORD", "stream": "errors_last7days", "record": {"date": "2025-10-31T00:00:00+00:00", "total": 878, "errors": [{"errorCode": "610", "count": 10}, {"errorCode": "1019", "count": 707}, {"errorCode": "1029", "count": 3}, {"errorCode": "1003", "count": 158}]}, "time_extracted": "2025-11-06T15:13:33.151823Z"}
INFO errors_last7days: finished sync
```
 
# Risks
 - No immediate risks, as this an additional feature, outside of the critical path for existing features.
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
