### PR TITLE
improve memory usage

### DIFF
--- a/tap_marketo/client.py
+++ b/tap_marketo/client.py
@@ -280,7 +280,8 @@ class Client:
         endpoint_name = "{}_stream".format(stream_type)
         try:
             # Range described here: https://developers.marketo.com/rest-api/bulk-extract/#crayon-5e600bb5f1a53663868461
-            self.request("GET", endpoint, endpoint_name=endpoint_name, stream=True, headers={"Range": "bytes=0-0"})
+            resp = self.request("GET", endpoint, endpoint_name=endpoint_name, stream=True, headers={"Range": "bytes=0-0"})
+            resp.close()
             return True
         except requests.exceptions.HTTPError as ex:
             if ex.response.status_code == 404:

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -86,14 +86,26 @@ def format_value(value, schema):
     return value
 
 
-def format_values(stream, row):
-    rtn = {}
+def get_available_fields(stream):
+    """Return the set of selected/automatic field names for a stream.
 
-    available_fields = []
+    Computing this once per stream (rather than per row) avoids rebuilding the
+    set on every row processed during a bulk export.
+    """
+    available_fields = set()
     for entry in stream['metadata']:
-        if len(entry['breadcrumb']) > 0 and (entry['metadata'].get('selected') or entry['metadata'].get('inclusion') == 'automatic'):
-            available_fields.append(entry['breadcrumb'][-1])
+        if len(entry['breadcrumb']) > 0 and (
+            entry['metadata'].get('selected') or
+            entry['metadata'].get('inclusion') == 'automatic'
+        ):
+            available_fields.add(entry['breadcrumb'][-1])
+    return available_fields
 
+
+def format_values(stream, row, available_fields=None):
+    if available_fields is None:
+        available_fields = get_available_fields(stream)
+    rtn = {}
     for field, schema in stream["schema"]["properties"].items():
         if field in available_fields:
             rtn[field] = format_value(row.get(field), schema)
@@ -138,11 +150,14 @@ def stream_rows(client, stream_type, export_id):
     with tempfile.NamedTemporaryFile(mode="w+", encoding="utf8") as csv_file:
         singer.log_info("Download starting.")
         resp = client.stream_export(stream_type, export_id)
-        for chunk in resp.iter_content(chunk_size=CHUNK_SIZE_BYTES, decode_unicode=True):
-            if chunk:
-                # Replace CR
-                chunk = chunk.replace('\r', '')
-                csv_file.write(chunk)
+        try:
+            for chunk in resp.iter_content(chunk_size=CHUNK_SIZE_BYTES, decode_unicode=True):
+                if chunk:
+                    # Replace CR
+                    chunk = chunk.replace('\r', '')
+                    csv_file.write(chunk)
+        finally:
+            resp.close()
 
         singer.log_info("Download completed. Begin streaming rows.")
         csv_file.seek(0)
@@ -173,10 +188,7 @@ def get_or_create_export_for_leads(client, state, stream, export_start, config):
 
         # Create the new export and store the id and end date in state.
         # Does not start the export (must POST to the "enqueue" endpoint).
-        fields = []
-        for entry in stream['metadata']:
-            if len(entry['breadcrumb']) > 0 and (entry['metadata'].get('selected') or entry['metadata'].get('inclusion') == 'automatic'):
-                fields.append(entry['breadcrumb'][-1])
+        fields = list(get_available_fields(stream))
 
         export_id = client.create_export("leads", fields, query)
         state = update_state_with_export_info(
@@ -234,15 +246,11 @@ def get_or_create_export_for_activities(client, state, stream, export_start, con
     return export_id, export_end
 
 
-def flatten_activity(row, stream):
+def flatten_activity(row, pan_field):
     # Start with the base fields
     rtn = {field: row[field] for field in BASE_ACTIVITY_FIELDS}
 
-    # Add the primary attribute name
-    # This name is the human readable name/description of the
-    # pimaryAttribute
-    mdata = metadata.to_map(stream['metadata'])
-    pan_field = metadata.get(mdata, (), 'marketo.primary-attribute-name')
+    # pan_field is the pre-computed primary attribute field name for this stream.
     if pan_field:
         rtn['primary_attribute_name'] = pan_field
         rtn['primary_attribute_value'] = row['primaryAttributeValue']
@@ -271,13 +279,14 @@ def sync_leads(client, state, stream, config):
     job_started = pendulum.utcnow()
     record_count = 0
     max_bookmark = initial_bookmark
+    available_fields = get_available_fields(stream)
     while export_start < job_started:
         export_id, export_end = get_or_create_export_for_leads(client, state, stream, export_start, config)
         state = wait_for_export(client, state, stream, export_id)
         for row in stream_rows(client, "leads", export_id):
             time_extracted = utils.now()
 
-            record = format_values(stream, row)
+            record = format_values(stream, row, available_fields)
             record_bookmark = pendulum.parse(record[replication_key])
 
             if client.use_corona:
@@ -305,14 +314,19 @@ def sync_activities(client, state, stream, config):
     export_start = pendulum.parse(bookmarks.get_bookmark(state, stream["tap_stream_id"], replication_key))
     job_started = pendulum.utcnow()
     record_count = 0
+
+    activity_metadata = metadata.to_map(stream["metadata"])
+    pan_field = metadata.get(activity_metadata, (), 'marketo.primary-attribute-name')
+    available_fields = get_available_fields(stream)
+
     while export_start < job_started:
         export_id, export_end = get_or_create_export_for_activities(client, state, stream, export_start, config)
         state = wait_for_export(client, state, stream, export_id)
         for row in stream_rows(client, "activities", export_id):
             time_extracted = utils.now()
 
-            row = flatten_activity(row, stream)
-            record = format_values(stream, row)
+            row = flatten_activity(row, pan_field)
+            record = format_values(stream, row, available_fields)
 
             singer.write_record(stream["tap_stream_id"], record, time_extracted=time_extracted)
             record_count += 1
@@ -347,6 +361,7 @@ def sync_programs(client, state, stream):
     endpoint = "rest/asset/v1/programs.json"
 
     record_count = 0
+    available_fields = get_available_fields(stream)
     while True:
         data = client.request("GET", endpoint, endpoint_name="programs", params=params)
 
@@ -360,7 +375,7 @@ def sync_programs(client, state, stream):
         # Each row just needs the values formatted. If the record is
         # newer than the original start date, stream the record.
         for row in data["result"]:
-            record = format_values(stream, row)
+            record = format_values(stream, row, available_fields)
             if record[replication_key] >= start_date:
                 record_count += 1
 
@@ -400,6 +415,7 @@ def sync_paginated(client, state, stream):
     # Keep querying pages of data until no next page token.
     record_count = 0
     job_started = pendulum.utcnow().isoformat()
+    available_fields = get_available_fields(stream)
     while True:
         data = client.request("GET", endpoint, endpoint_name=stream["tap_stream_id"], params=params)
 
@@ -409,7 +425,7 @@ def sync_paginated(client, state, stream):
         # newer than the original start date, stream the record. Finally,
         # update the bookmark if newer than the existing bookmark.
         for row in data["result"]:
-            record = format_values(stream, row)
+            record = format_values(stream, row, available_fields)
             if record[replication_key] >= start_date:
                 record_count += 1
 
@@ -442,11 +458,12 @@ def sync_activity_types(client, state, stream):
     endpoint = "rest/v1/activities/types.json"
     data = client.request("GET", endpoint, endpoint_name="activity_types")
     record_count = 0
+    available_fields = get_available_fields(stream)
 
     time_extracted = utils.now()
 
     for row in data["result"]:
-        record = format_values(stream, row)
+        record = format_values(stream, row, available_fields)
         record_count += 1
 
         singer.write_record("activity_types", record, time_extracted=time_extracted)


### PR DESCRIPTION
# Description of change


Github Copilot identified these high value fixes related to the tap running out of memory:

🔴 High: format_values rebuilds field list on every row (sync.py:89–99)

 def format_values(stream, row):
     available_fields = []
     for entry in stream['metadata']:   # ← repeated for EVERY row
         ...

For large exports (millions of rows), this allocates and discards a new list + iterates all stream metadata fields on every single row. This creates enormous GC pressure and fragmentation in CPython's arena allocator, which doesn't return freed memory to the OS.

🔴 High: flatten_activity calls metadata.to_map() on every row (sync.py:244)

 def flatten_activity(row, stream):
     mdata = metadata.to_map(stream['metadata'])  # ← called for EVERY row

Same issue — creates a new dict from full stream metadata for each activity row.


## Memory / OOM Fix Summary
 
 ### Root Causes
 Two functions in `sync.py` rebuilt expensive data structures on **every row**
 during bulk exports, causing heap fragmentation in CPython. Streaming HTTP
 responses were also never explicitly closed, risking connection leaks when GC
 is delayed under memory pressure.
 
 ---
 
 ### Changes
 
 **`tap_marketo/sync.py`**
 
 - **New `get_available_fields(stream)`** — extracts field-set computation into
   a helper returning a `set` (O(1) lookups vs the previous O(n) list).
 - **`format_values`** — accepts an optional pre-computed `available_fields`;
   all hot-loop callers now pass it in instead of recomputing per row.
 - **`flatten_activity(row, pan_field)`** — takes `pan_field` directly instead
   of `stream`, removing a `metadata.to_map()` call on every activity row.
 - **`sync_leads` / `sync_activities`** — pre-compute `available_fields` (and
   `pan_field` for activities) once before the export loop.
 - **`sync_programs` / `sync_paginated` / `sync_activity_types`** — same
   pre-computation applied for consistency.
 - **`get_or_create_export_for_leads`** — replaced duplicate inline metadata
   iteration with `list(get_available_fields(stream))`.
 - **`stream_rows`** — wrapped `resp.iter_content(...)` in `try/finally
   resp.close()` to guarantee the TCP connection is released on exceptions.
 
 **`tap_marketo/client.py`**
 
 - **`export_file_exists`** — calls `resp.close()` after the `bytes=0-0` range
   probe to prevent connection pool leaks from unclosed streaming responses.
 
 ---

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool
