### PR TITLE
do not stream rows into tempfile on im-memory volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 2.8.0
+  * Stream HTTP data directly to generator rather than dowloading entire response to a tempfile
+  * Small improvements to memory usage
+  * [#109](https://github.com/singer-io/tap-marketo/pull/109)
+  * [#111](https://github.com/singer-io/tap-marketo/pull/111)
+
 # 2.7.2
   * Do not sync programs when start_date >= now [#107](https://github.com/singer-io/tap-marketo/pull/107)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-marketo',
-      version='2.7.2',
+      version='2.8.0',
       description='Singer.io tap for extracting data from the Marketo API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_marketo/client.py
+++ b/tap_marketo/client.py
@@ -280,7 +280,8 @@ class Client:
         endpoint_name = "{}_stream".format(stream_type)
         try:
             # Range described here: https://developers.marketo.com/rest-api/bulk-extract/#crayon-5e600bb5f1a53663868461
-            self.request("GET", endpoint, endpoint_name=endpoint_name, stream=True, headers={"Range": "bytes=0-0"})
+            resp = self.request("GET", endpoint, endpoint_name=endpoint_name, stream=True, headers={"Range": "bytes=0-0"})
+            resp.close()
             return True
         except requests.exceptions.HTTPError as ex:
             if ex.response.status_code == 404:

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -86,14 +86,26 @@ def format_value(value, schema):
     return value
 
 
-def format_values(stream, row):
-    rtn = {}
+def get_available_fields(stream):
+    """Return the set of selected/automatic field names for a stream.
 
-    available_fields = []
+    Computing this once per stream (rather than per row) avoids rebuilding the
+    set on every row processed during a bulk export.
+    """
+    available_fields = set()
     for entry in stream['metadata']:
-        if len(entry['breadcrumb']) > 0 and (entry['metadata'].get('selected') or entry['metadata'].get('inclusion') == 'automatic'):
-            available_fields.append(entry['breadcrumb'][-1])
+        if len(entry['breadcrumb']) > 0 and (
+            entry['metadata'].get('selected') or
+            entry['metadata'].get('inclusion') == 'automatic'
+        ):
+            available_fields.add(entry['breadcrumb'][-1])
+    return available_fields
 
+
+def format_values(stream, row, available_fields=None):
+    if available_fields is None:
+        available_fields = get_available_fields(stream)
+    rtn = {}
     for field, schema in stream["schema"]["properties"].items():
         if field in available_fields:
             rtn[field] = format_value(row.get(field), schema)
@@ -162,6 +174,7 @@ def stream_rows(client, stream_type, export_id):
             (line.replace('\r', '').replace('\0', '') for line in text_stream),
             delimiter=',', quotechar='"'
         )
+
         headers = next(reader)
         for line in reader:
             yield dict(zip(headers, line))
@@ -189,10 +202,7 @@ def get_or_create_export_for_leads(client, state, stream, export_start, config):
 
         # Create the new export and store the id and end date in state.
         # Does not start the export (must POST to the "enqueue" endpoint).
-        fields = []
-        for entry in stream['metadata']:
-            if len(entry['breadcrumb']) > 0 and (entry['metadata'].get('selected') or entry['metadata'].get('inclusion') == 'automatic'):
-                fields.append(entry['breadcrumb'][-1])
+        fields = list(get_available_fields(stream))
 
         export_id = client.create_export("leads", fields, query)
         state = update_state_with_export_info(
@@ -250,15 +260,11 @@ def get_or_create_export_for_activities(client, state, stream, export_start, con
     return export_id, export_end
 
 
-def flatten_activity(row, stream):
+def flatten_activity(row, pan_field):
     # Start with the base fields
     rtn = {field: row[field] for field in BASE_ACTIVITY_FIELDS}
 
-    # Add the primary attribute name
-    # This name is the human readable name/description of the
-    # pimaryAttribute
-    mdata = metadata.to_map(stream['metadata'])
-    pan_field = metadata.get(mdata, (), 'marketo.primary-attribute-name')
+    # pan_field is the pre-computed primary attribute field name for this stream.
     if pan_field:
         rtn['primary_attribute_name'] = pan_field
         rtn['primary_attribute_value'] = row['primaryAttributeValue']
@@ -287,13 +293,14 @@ def sync_leads(client, state, stream, config):
     job_started = pendulum.utcnow()
     record_count = 0
     max_bookmark = initial_bookmark
+    available_fields = get_available_fields(stream)
     while export_start < job_started:
         export_id, export_end = get_or_create_export_for_leads(client, state, stream, export_start, config)
         state = wait_for_export(client, state, stream, export_id)
         for row in stream_rows(client, "leads", export_id):
             time_extracted = utils.now()
 
-            record = format_values(stream, row)
+            record = format_values(stream, row, available_fields)
             record_bookmark = pendulum.parse(record[replication_key])
 
             if client.use_corona:
@@ -321,14 +328,19 @@ def sync_activities(client, state, stream, config):
     export_start = pendulum.parse(bookmarks.get_bookmark(state, stream["tap_stream_id"], replication_key))
     job_started = pendulum.utcnow()
     record_count = 0
+
+    activity_metadata = metadata.to_map(stream["metadata"])
+    pan_field = metadata.get(activity_metadata, (), 'marketo.primary-attribute-name')
+    available_fields = get_available_fields(stream)
+
     while export_start < job_started:
         export_id, export_end = get_or_create_export_for_activities(client, state, stream, export_start, config)
         state = wait_for_export(client, state, stream, export_id)
         for row in stream_rows(client, "activities", export_id):
             time_extracted = utils.now()
 
-            row = flatten_activity(row, stream)
-            record = format_values(stream, row)
+            row = flatten_activity(row, pan_field)
+            record = format_values(stream, row, available_fields)
 
             singer.write_record(stream["tap_stream_id"], record, time_extracted=time_extracted)
             record_count += 1
@@ -368,6 +380,7 @@ def sync_programs(client, state, stream):
     endpoint = "rest/asset/v1/programs.json"
 
     record_count = 0
+    available_fields = get_available_fields(stream)
     while True:
         data = client.request("GET", endpoint, endpoint_name="programs", params=params)
 
@@ -381,7 +394,7 @@ def sync_programs(client, state, stream):
         # Each row just needs the values formatted. If the record is
         # newer than the original start date, stream the record.
         for row in data["result"]:
-            record = format_values(stream, row)
+            record = format_values(stream, row, available_fields)
             if record[replication_key] >= start_date:
                 record_count += 1
 
@@ -421,6 +434,7 @@ def sync_paginated(client, state, stream):
     # Keep querying pages of data until no next page token.
     record_count = 0
     job_started = pendulum.utcnow().isoformat()
+    available_fields = get_available_fields(stream)
     while True:
         data = client.request("GET", endpoint, endpoint_name=stream["tap_stream_id"], params=params)
 
@@ -430,7 +444,7 @@ def sync_paginated(client, state, stream):
         # newer than the original start date, stream the record. Finally,
         # update the bookmark if newer than the existing bookmark.
         for row in data["result"]:
-            record = format_values(stream, row)
+            record = format_values(stream, row, available_fields)
             if record[replication_key] >= start_date:
                 record_count += 1
 
@@ -463,11 +477,12 @@ def sync_activity_types(client, state, stream):
     endpoint = "rest/v1/activities/types.json"
     data = client.request("GET", endpoint, endpoint_name="activity_types")
     record_count = 0
+    available_fields = get_available_fields(stream)
 
     time_extracted = utils.now()
 
     for row in data["result"]:
-        record = format_values(stream, row)
+        record = format_values(stream, row, available_fields)
         record_count += 1
 
         singer.write_record("activity_types", record, time_extracted=time_extracted)

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -1,7 +1,7 @@
 import csv
+import io
 import json
 import pendulum
-import tempfile
 
 import singer
 from singer import metadata
@@ -132,25 +132,41 @@ MEGABYTE_IN_BYTES = 1024 * 1024
 CHUNK_SIZE_MB = 10
 CHUNK_SIZE_BYTES = MEGABYTE_IN_BYTES * CHUNK_SIZE_MB
 
-# This function has an issue with UTF-8 data most likely caused by decode_unicode=True
-# See https://github.com/singer-io/tap-marketo/pull/51/files
+class IterStream(io.RawIOBase):
+    """Adapts a byte-chunk iterator into a file-like object for io.BufferedReader/TextIOWrapper."""
+
+    def __init__(self, iterator):
+        self._iter = iterator
+        self._leftover = b''
+
+    def readable(self):
+        return True
+
+    def readinto(self, buf):
+        try:
+            chunk = self._leftover or next(self._iter)
+            out, self._leftover = chunk[:len(buf)], chunk[len(buf):]
+            buf[:len(out)] = out
+            return len(out)
+        except StopIteration:
+            return 0
+
+
 def stream_rows(client, stream_type, export_id):
-    with tempfile.NamedTemporaryFile(mode="w+", encoding="utf8") as csv_file:
-        singer.log_info("Download starting.")
-        resp = client.stream_export(stream_type, export_id)
-        for chunk in resp.iter_content(chunk_size=CHUNK_SIZE_BYTES, decode_unicode=True):
-            if chunk:
-                # Replace CR
-                chunk = chunk.replace('\r', '')
-                csv_file.write(chunk)
-
-        singer.log_info("Download completed. Begin streaming rows.")
-        csv_file.seek(0)
-
-        reader = csv.reader((line.replace('\0', '') for line in csv_file), delimiter=',', quotechar='"')
+    singer.log_info("Download starting.")
+    resp = client.stream_export(stream_type, export_id)
+    try:
+        chunks = resp.iter_content(chunk_size=CHUNK_SIZE_BYTES, decode_unicode=False)
+        text_stream = io.TextIOWrapper(io.BufferedReader(IterStream(chunks)), encoding='utf-8')
+        reader = csv.reader(
+            (line.replace('\r', '').replace('\0', '') for line in text_stream),
+            delimiter=',', quotechar='"'
+        )
         headers = next(reader)
         for line in reader:
             yield dict(zip(headers, line))
+    finally:
+        resp.close()
 
 
 def get_or_create_export_for_leads(client, state, stream, export_start, config):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -20,11 +20,14 @@ def parse_params(request):
 
 class MockResponse:
     def __init__(self, data):
-        self.data = data
-    def iter_content(self, decode_unicode=True, chunk_size=512):
+        self.data = data if isinstance(data, bytes) else data.encode('utf-8')
+        self.closed = False
+    def iter_content(self, decode_unicode=False, chunk_size=512):
         yield self.data
-    def iter_lines(self, decode_unicode=True, chunk_size=512):
+    def iter_lines(self, decode_unicode=False, chunk_size=512):
         yield self.data
+    def close(self):
+        self.closed = True
 
 
 class TestSyncPrograms(unittest.TestCase):
@@ -524,3 +527,99 @@ class TestSyncPrograms(unittest.TestCase):
 #                                 "activityTypeId": 1, "primary_attribute_value_id": None, "primary_attribute_name": "webpage_id", "primary_attribute_value": '1', "client_ip_address": "0.0.0.0"}),
 #         ]
 #         write_record.assert_has_calls(expected_calls)
+
+
+class TestIterStream(unittest.TestCase):
+    def test_reads_single_chunk(self):
+        chunks = iter([b'hello,world\n'])
+        stream = IterStream(chunks)
+        result = stream.read()
+        self.assertEqual(b'hello,world\n', result)
+
+    def test_reads_across_multiple_chunks(self):
+        chunks = iter([b'hel', b'lo,', b'wor', b'ld\n'])
+        stream = IterStream(chunks)
+        result = stream.read()
+        self.assertEqual(b'hello,world\n', result)
+
+    def test_leftover_bytes_carried_forward(self):
+        # readinto buf is smaller than the chunk — leftover must be preserved
+        chunks = iter([b'abcdef'])
+        stream = IterStream(chunks)
+        buf = bytearray(4)
+        n = stream.readinto(buf)
+        self.assertEqual(4, n)
+        self.assertEqual(b'abcd', bytes(buf))
+        buf2 = bytearray(4)
+        n2 = stream.readinto(buf2)
+        self.assertEqual(2, n2)
+        self.assertEqual(b'ef', bytes(buf2[:n2]))
+
+    def test_returns_zero_on_exhausted_iterator(self):
+        chunks = iter([])
+        stream = IterStream(chunks)
+        buf = bytearray(4)
+        self.assertEqual(0, stream.readinto(buf))
+
+
+class TestStreamRows(unittest.TestCase):
+    def _make_mock_client(self, chunks):
+        """Return a mock client whose stream_export yields the given byte chunks."""
+        class MultiChunkResponse:
+            def __init__(self, byte_chunks):
+                self._chunks = byte_chunks
+                self.closed = False
+            def iter_content(self, decode_unicode=False, chunk_size=512):
+                yield from self._chunks
+            def close(self):
+                self.closed = True
+
+        client = unittest.mock.MagicMock()
+        resp = MultiChunkResponse(chunks)
+        client.stream_export.return_value = resp
+        return client, resp
+
+    def test_basic_csv_parsing(self):
+        data = b'id,name\n1,Alice\n2,Bob\n'
+        client, _ = self._make_mock_client([data])
+        rows = list(stream_rows(client, 'leads', 'export-1'))
+        self.assertEqual([{'id': '1', 'name': 'Alice'}, {'id': '2', 'name': 'Bob'}], rows)
+
+    def test_cr_stripped(self):
+        data = b'id,name\r\n1,Alice\r\n'
+        client, _ = self._make_mock_client([data])
+        rows = list(stream_rows(client, 'leads', 'export-1'))
+        self.assertEqual([{'id': '1', 'name': 'Alice'}], rows)
+
+    def test_null_bytes_stripped(self):
+        data = b'id,name\n1,Ali\x00ce\n'
+        client, _ = self._make_mock_client([data])
+        rows = list(stream_rows(client, 'leads', 'export-1'))
+        self.assertEqual([{'id': '1', 'name': 'Alice'}], rows)
+
+    def test_response_closed_after_iteration(self):
+        data = b'id\n1\n'
+        client, resp = self._make_mock_client([data])
+        list(stream_rows(client, 'leads', 'export-1'))
+        self.assertTrue(resp.closed)
+
+    def test_response_closed_on_exception(self):
+        # Even if iteration raises, resp.close() must still be called.
+        # An empty chunk produces no headers; next(reader) raises StopIteration,
+        # which Python 3.7+ (PEP 479) converts to RuntimeError inside a generator.
+        client, resp = self._make_mock_client([b''])
+        try:
+            list(stream_rows(client, 'leads', 'export-1'))
+        except (StopIteration, RuntimeError):
+            pass
+        self.assertTrue(resp.closed)
+
+    def test_multibyte_utf8_split_across_chunks(self):
+        # 'café' encoded as UTF-8: b'caf\xc3\xa9' (\xc3\xa9 is a 2-byte sequence).
+        # Split the chunk boundary between the two bytes of the multi-byte character.
+        row = 'id,name\n1,café\n'.encode('utf-8')
+        split = row.index(b'\xc3') + 1  # after \xc3, before \xa9
+        chunk1, chunk2 = row[:split], row[split:]
+        client, _ = self._make_mock_client([chunk1, chunk2])
+        rows = list(stream_rows(client, 'leads', 'export-1'))
+        self.assertEqual([{'id': '1', 'name': 'café'}], rows)


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-31211

## Problem

`stream_rows` in `sync.py` buffers the entire bulk export CSV to a `NamedTemporaryFile` before
reading it back row-by-row. Because `/tmp` in the pod is backed by an in-memory `emptyDir` tmpfs
volume, this means the full export exists in RAM twice simultaneously: once as the tmpfs file and
once as the Python objects during row processing. This was the root cause of the OOM kill observed
in production for a `tap-marketo` leads export.

The temp file was introduced as a workaround for a UTF-8 decoding bug: using
`iter_content(decode_unicode=True)` can corrupt multi-byte UTF-8 characters that happen to be
split across chunk boundaries.

## Solution

Replace the temp file with a true streaming pipeline using Python's standard `io` stack:

1. `resp.iter_content(chunk_size=CHUNK_SIZE_BYTES, decode_unicode=False)` — fetch raw bytes
2. `IterStream(io.RawIOBase)` — adapts the byte iterator into a file-like object
3. `io.BufferedReader(IterStream(...))` — adds buffering required by `TextIOWrapper`
4. `io.TextIOWrapper(..., encoding='utf-8')` — handles incremental UTF-8 decoding correctly
   across chunk boundaries, fixing the root cause of the original workaround

`csv.reader` receives the `TextIOWrapper` directly (via a generator that applies `\r` and `\0`
stripping per line). No data is buffered to disk or accumulated in memory.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [X] this PR has been written with the help of GitHub Copilot or another generative AI tool
