### PR TITLE
bulk request window shrinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 2.9.0
+  * Shrink bulk request window on ApiQuotaExceeded exception [#112](https://github.com/singer-io/tap-marketo/pull/112)
+
 # 2.8.0
   * Stream HTTP data directly to generator rather than dowloading entire response to a tempfile
   * Small improvements to memory usage

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-marketo',
-      version='2.8.0',
+      version='2.9.0',
       description='Singer.io tap for extracting data from the Marketo API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -130,6 +130,44 @@ def get_export_end(export_start, end_days=MAX_EXPORT_DAYS):
     return export_end.replace(microsecond=0)
 
 
+# Marketo's bulk extract API enforces a daily data-volume quota. A single
+# wide export window can produce a file too large to extract, which fails
+# with ApiQuotaExceeded (1029) and returns no data at all. When that happens
+# we halve the window and retry so we can still make forward progress, down
+# to a floor of MIN_EXPORT_DAYS. If even the smallest window exceeds quota we
+# re-raise so downstream processes see the failure.
+MIN_EXPORT_DAYS = 2
+
+
+def create_export_with_quota_backoff(create_fn, export_start, max_export_days):
+    """Create a bulk export for the window starting at ``export_start``.
+
+    ``create_fn`` is called with the chosen ``export_end`` and must return the
+    new export id. On ApiQuotaExceeded we halve the window (bounded below by
+    MIN_EXPORT_DAYS) and retry; if the minimum window still exceeds quota the
+    error is re-raised. Returns ``(export_id, export_end)``.
+    """
+    export_end = get_export_end(export_start, end_days=max_export_days)
+    while True:
+        try:
+            export_id = create_fn(export_end)
+            return export_id, export_end
+        except ApiQuotaExceeded as e:
+            # in_days() floors to whole days, matching how we size windows.
+            window_days = (export_end - export_start).in_days()
+            if window_days <= MIN_EXPORT_DAYS:
+                raise ApiQuotaExceeded(
+                    ("Unable to create an export for the window starting {} "
+                     "within your Marketo API quota, even after shrinking it "
+                     "to {} day(s).").format(export_start.isoformat(),
+                                             window_days)) from e
+            new_days = max(MIN_EXPORT_DAYS, window_days // 2)
+            singer.log_warning(
+                "Hit Marketo API quota creating export; retrying with a "
+                "smaller %s-day window (was %s days).", new_days, window_days)
+            export_end = get_export_end(export_start, end_days=new_days)
+
+
 def wait_for_export(client, state, stream, export_id):
     stream_type = "activities" if stream["tap_stream_id"] != "leads" else "leads"
     try:
@@ -195,16 +233,20 @@ def get_or_create_export_for_leads(client, state, stream, export_start, config):
         query_field = "updatedAt" if client.use_corona else "createdAt"
         max_export_days = int(config.get('max_export_days',
                                          MAX_EXPORT_DAYS))
-        export_end = get_export_end(export_start,
-                                    end_days=max_export_days)
-        query = {query_field: {"startAt": export_start.isoformat(),
-                               "endAt": export_end.isoformat()}}
+        fields = list(get_available_fields(stream))
+
+        def create(export_end):
+            query = {query_field: {"startAt": export_start.isoformat(),
+                                   "endAt": export_end.isoformat()}}
+            return client.create_export("leads", fields, query)
 
         # Create the new export and store the id and end date in state.
         # Does not start the export (must POST to the "enqueue" endpoint).
-        fields = list(get_available_fields(stream))
-
-        export_id = client.create_export("leads", fields, query)
+        export_id, export_end = create_export_with_quota_backoff(
+            create,
+            export_start,
+            max_export_days
+        )
         state = update_state_with_export_info(
             state, stream, export_id=export_id, export_end=export_end.isoformat())
     else:
@@ -232,26 +274,19 @@ def get_or_create_export_for_activities(client, state, stream, export_start, con
         # largest date range that can be used for activities is 30 days.
         max_export_days = int(config.get('max_export_days',
                                          MAX_EXPORT_DAYS))
-        export_end = get_export_end(export_start,
-                                    end_days=max_export_days)
-        query = {"createdAt": {"startAt": export_start.isoformat(),
-                               "endAt": export_end.isoformat()},
-                 "activityTypeIds": [activity_type_id]}
+
+        def create(export_end):
+            query = {"createdAt": {"startAt": export_start.isoformat(),
+                                   "endAt": export_end.isoformat()},
+                     "activityTypeIds": [activity_type_id]}
+            return client.create_export("activities", ACTIVITY_FIELDS, query)
 
         # Create the new export and store the id and end date in state.
         # Does not start the export (must POST to the "enqueue" endpoint).
-        try:
-            export_id = client.create_export("activities", ACTIVITY_FIELDS, query)
-        except ApiQuotaExceeded as e:
-            # The main reason we wrap the ApiQuotaExceeded exception in a
-            # new one is to be able to tell the customer what their
-            # configured max_export_days is.
-            raise ApiQuotaExceeded(
-                ("You may wish to consider changing the "
-                 "`max_export_days` config value to a lower number if "
-                 "you're unable to sync a single {} day window within "
-                 "your current API quota.").format(
-                     max_export_days)) from e
+        # The window is automatically shrunk and retried if a single window
+        # is too large to extract within the daily API quota.
+        export_id, export_end = create_export_with_quota_backoff(
+            create, export_start, max_export_days)
         state = update_state_with_export_info(
             state, stream, export_id=export_id, export_end=export_end.isoformat())
     else:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -6,7 +6,7 @@ import freezegun
 import pendulum
 import requests_mock
 
-from tap_marketo.client import Client, ApiException
+from tap_marketo.client import Client, ApiException, ApiQuotaExceeded
 from tap_marketo.discover import (discover_catalog,
                                   ACTIVITY_TYPES_AUTOMATIC_INCLUSION,
                                   ACTIVITY_TYPES_UNSUPPORTED,
@@ -623,3 +623,76 @@ class TestStreamRows(unittest.TestCase):
         client, _ = self._make_mock_client([chunk1, chunk2])
         rows = list(stream_rows(client, 'leads', 'export-1'))
         self.assertEqual([{'id': '1', 'name': 'café'}], rows)
+
+
+@freezegun.freeze_time("2017-02-15")
+class TestCreateExportWithQuotaBackoff(unittest.TestCase):
+    # export_start is well in the past so the full window isn't capped at "now".
+    export_start = pendulum.parse("2017-01-01T00:00:00+00:00")
+
+    def _days(self, export_end):
+        return (export_end - self.export_start).in_days()
+
+    def test_succeeds_on_first_try_uses_full_window(self):
+        calls = []
+
+        def create(export_end):
+            calls.append(self._days(export_end))
+            return "export-123"
+
+        export_id, export_end = create_export_with_quota_backoff(
+            create, self.export_start, 30)
+
+        self.assertEqual("export-123", export_id)
+        self.assertEqual([30], calls)
+        self.assertEqual(30, self._days(export_end))
+
+    @unittest.mock.patch("singer.log_warning")
+    def test_halves_window_until_it_fits(self, _log_warning):
+        calls = []
+
+        def create(export_end):
+            days = self._days(export_end)
+            calls.append(days)
+            if days > 7:
+                raise ApiQuotaExceeded("window too large")
+            return "export-123"
+
+        export_id, export_end = create_export_with_quota_backoff(
+            create, self.export_start, 30)
+
+        # 30 -> 15 -> 7, halving until the window is small enough to extract.
+        self.assertEqual("export-123", export_id)
+        self.assertEqual([30, 15, 7], calls)
+        self.assertEqual(7, self._days(export_end))
+
+    @unittest.mock.patch("singer.log_warning")
+    def test_reraises_when_minimum_window_still_exceeds_quota(self, _log_warning):
+        calls = []
+
+        def create(export_end):
+            calls.append(self._days(export_end))
+            raise ApiQuotaExceeded("window too large")
+
+        with self.assertRaises(ApiQuotaExceeded):
+            create_export_with_quota_backoff(create, self.export_start, 30)
+
+        # Shrinks down to the MIN_EXPORT_DAYS floor before giving up.
+        self.assertEqual([30, 15, 7, 3, 2], calls)
+        self.assertEqual(MIN_EXPORT_DAYS, calls[-1])
+
+    @unittest.mock.patch("singer.log_warning")
+    def test_does_not_shrink_below_minimum_for_small_window(self, _log_warning):
+        # A naturally small window (capped near "now") that still fails should
+        # raise immediately rather than retry below the floor.
+        small_start = pendulum.parse("2017-02-14T00:00:00+00:00")  # ~1 day before now
+        calls = []
+
+        def create(export_end):
+            calls.append((export_end - small_start).in_days())
+            raise ApiQuotaExceeded("window too large")
+
+        with self.assertRaises(ApiQuotaExceeded):
+            create_export_with_quota_backoff(create, small_start, 30)
+
+        self.assertEqual(1, len(calls))


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-31211

Adds `create_export_with_quota_backoff` which reduces export window on ApiQuotaExceeded exception.

Logs from local test:

```
INFO Scheduling export job with query {'updatedAt': {'startAt': '2026-03-27T00:00:00+00:00', 'endAt': '2026-04-26T00:00:00+00:00'}}
...
WARNING Hit Marketo API quota creating export; retrying with a smaller 15-day window (was 30 days).
...
WARNING Hit Marketo API quota creating export; retrying with a smaller 7-day window (was 15 days).
...
WARNING Hit Marketo API quota creating export; retrying with a smaller 3-day window (was 7 days).
...
WARNING Hit Marketo API quota creating export; retrying with a smaller 2-day window (was 3 days).
...
CRITICAL Unable to create an export for the window starting 2026-03-27T00:00:00+00:00 within your Marketo API quota, even after shrinking it to 2 day(s).
...
tap_marketo.client.ApiQuotaExceeded: Marketo API returned error(s): [{'code': '1029', 'message': 'Export daily quota 500MB exceeded.'}]. Data can resume replicating at midnight central time. Read more about Marketo Bulk API limits here: http://developers.marketo.com/rest-api/bulk-extract/#limits
```


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
