### PR TITLE
SAC-31211: resume download on broken pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 2.9.1
+  * Resume bulk export downloads via a byte-range request when the connection is dropped mid-stream [#113](https://github.com/singer-io/tap-marketo/pull/113)
+
 # 2.9.0
   * Shrink bulk request window on ApiQuotaExceeded exception [#112](https://github.com/singer-io/tap-marketo/pull/112)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-marketo',
-      version='2.9.0',
+      version='2.9.1',
       description='Singer.io tap for extracting data from the Marketo API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_marketo/client.py
+++ b/tap_marketo/client.py
@@ -303,11 +303,15 @@ class Client:
         # http://developers.marketo.com/rest-api/bulk-extract/#polling_job_status
         return self.get_export_status(stream_type, export_id)["result"][0]["status"]
 
-    def stream_export(self, stream_type, export_id):
+    def stream_export(self, stream_type, export_id, start_byte=0):
         # http://developers.marketo.com/rest-api/bulk-extract/#retrieving_your_data
         endpoint = self.get_bulk_endpoint(stream_type, "file", export_id)
         endpoint_name = "{}_stream".format(stream_type)
-        return self.request("GET", endpoint, endpoint_name=endpoint_name, stream=True)
+        kwargs = {}
+        if start_byte:
+            # Resume a partially-downloaded export from where a dropped connection left off.
+            kwargs["headers"] = {"Range": "bytes={}-".format(start_byte)}
+        return self.request("GET", endpoint, endpoint_name=endpoint_name, stream=True, **kwargs)
 
     def wait_for_export(self, stream_type, export_id):
         # Poll the export status until it enters a finalized state or

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -2,6 +2,7 @@ import csv
 import io
 import json
 import pendulum
+from requests.exceptions import ChunkedEncodingError, ConnectionError
 
 import singer
 from singer import metadata
@@ -201,13 +202,48 @@ class IterStream(io.RawIOBase):
         except StopIteration:
             return 0
 
+MAX_EMPTY_RESUMES = 5
+
+def resumable_iter_content(client, stream_type, export_id):
+    """Yield the export file's bytes, reconnecting on a dropped connection.
+
+    Marketo drops the bulk-export download connection when it is held open too
+    long -- e.g. while the tap is reading at the pace of a slower target. The
+    export file is static and supports byte ranges, so we recover by
+    re-requesting from the byte offset already yielded and continuing. Resuming
+    here, below the CSV parser, keeps the byte stream contiguous so callers
+    never see the seam.
+    """
+    start_byte = 0
+    empty_resumes = 0
+    while True:
+        resp = client.stream_export(stream_type, export_id, start_byte=start_byte)
+        bytes_this_connection = 0
+        try:
+            for chunk in resp.iter_content(chunk_size=CHUNK_SIZE_BYTES, decode_unicode=False):
+                bytes_this_connection += len(chunk)
+                start_byte += len(chunk)
+                yield chunk
+            return
+        except (ChunkedEncodingError, ConnectionError) as ex:
+            if bytes_this_connection:
+                empty_resumes = 0
+            else:
+                empty_resumes += 1
+                if empty_resumes > MAX_EMPTY_RESUMES:
+                    raise ex
+            singer.log_warning(
+                "Export download connection dropped after %s bytes; resuming "
+                "from byte %s: %s.", bytes_this_connection, start_byte, ex)
+        finally:
+            resp.close()
+
 
 def stream_rows(client, stream_type, export_id):
     singer.log_info("Download starting.")
-    resp = client.stream_export(stream_type, export_id)
+    chunks = resumable_iter_content(client, stream_type, export_id)
+    text_stream = io.TextIOWrapper(io.BufferedReader(IterStream(chunks)), encoding='utf-8')
     try:
-        chunks = resp.iter_content(chunk_size=CHUNK_SIZE_BYTES, decode_unicode=False)
-        text_stream = io.TextIOWrapper(io.BufferedReader(IterStream(chunks)), encoding='utf-8')
         reader = csv.reader(
             (line.replace('\r', '').replace('\0', '') for line in text_stream),
             delimiter=',', quotechar='"'
@@ -217,7 +253,8 @@ def stream_rows(client, stream_type, export_id):
         for line in reader:
             yield dict(zip(headers, line))
     finally:
-        resp.close()
+        text_stream.close()
+        chunks.close()
 
 
 def get_or_create_export_for_leads(client, state, stream, export_start, config):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -4,6 +4,7 @@ import urllib.parse
 
 import freezegun
 import pendulum
+from requests.exceptions import ChunkedEncodingError, ConnectionError
 import requests_mock
 
 from tap_marketo.client import Client, ApiException, ApiQuotaExceeded
@@ -623,6 +624,77 @@ class TestStreamRows(unittest.TestCase):
         client, _ = self._make_mock_client([chunk1, chunk2])
         rows = list(stream_rows(client, 'leads', 'export-1'))
         self.assertEqual([{'id': '1', 'name': 'café'}], rows)
+
+
+class TestResumableDownload(unittest.TestCase):
+    class ByteResponse:
+        """Yields its data one byte at a time, optionally dropping the
+        connection once a given number of bytes have been emitted."""
+        def __init__(self, data, fail_after=None):
+            self.data = data
+            self.fail_after = fail_after
+            self.closed = False
+
+        def iter_content(self, decode_unicode=False, chunk_size=512):
+            for i, b in enumerate(self.data):
+                if self.fail_after is not None and i >= self.fail_after:
+                    raise ChunkedEncodingError("connection dropped")
+                yield bytes([b])
+
+        def close(self):
+            self.closed = True
+
+    def _client(self, responses):
+        client = unittest.mock.MagicMock()
+        client.stream_export.side_effect = responses
+        return client
+
+    def test_resumes_from_byte_offset_after_drop(self):
+        full = b'id,name\n1,Alice\n2,Bob\n'
+        split = full.index(b'2,Bob')  # drop right at the start of the 2nd data row
+        client = self._client([
+            self.ByteResponse(full, fail_after=split),  # delivers header + row 1, then drops
+            self.ByteResponse(full[split:]),            # resumes with the remainder
+        ])
+
+        rows = list(stream_rows(client, 'leads', 'export-1'))
+
+        self.assertEqual([{'id': '1', 'name': 'Alice'}, {'id': '2', 'name': 'Bob'}], rows)
+        # The resume request must ask for exactly the bytes already consumed.
+        self.assertEqual(split, client.stream_export.call_args_list[1].kwargs['start_byte'])
+        self.assertEqual(2, client.stream_export.call_count)
+
+    def test_resumes_multiple_times(self):
+        full = b'id,n\n1,a\n2,b\n3,c\n'
+        client = self._client([
+            self.ByteResponse(full, fail_after=8),
+            self.ByteResponse(full[8:], fail_after=4),
+            self.ByteResponse(full[12:]),
+        ])
+
+        rows = list(stream_rows(client, 'leads', 'export-1'))
+
+        self.assertEqual(
+            [{'id': '1', 'n': 'a'}, {'id': '2', 'n': 'b'}, {'id': '3', 'n': 'c'}], rows)
+        self.assertEqual([0, 8, 12],
+                         [c.kwargs['start_byte'] for c in client.stream_export.call_args_list])
+
+    def test_all_responses_closed(self):
+        full = b'id\n1\n2\n'
+        responses = [self.ByteResponse(full, fail_after=4), self.ByteResponse(full[4:])]
+        client = self._client(responses)
+        list(stream_rows(client, 'leads', 'export-1'))
+        self.assertTrue(all(r.closed for r in responses))
+
+    def test_gives_up_after_repeated_zero_progress_resumes(self):
+        # A connection that drops before yielding any bytes can't make progress;
+        # after MAX_EMPTY_RESUMES retries we surface the error instead of looping.
+        responses = [self.ByteResponse(b'id\n1\n', fail_after=0)
+                     for _ in range(MAX_EMPTY_RESUMES + 5)]
+        client = self._client(responses)
+        with self.assertRaises(ChunkedEncodingError):
+            list(stream_rows(client, 'leads', 'export-1'))
+        self.assertEqual(MAX_EMPTY_RESUMES + 1, client.stream_export.call_count)
 
 
 @freezegun.freeze_time("2017-02-15")


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-31211

The change to [stop buffering bulk exports to a tempfile](https://github.com/singer-io/tap-marketo/pull/111) is causing issues for at least one customer:

```
2026-06-17 14:17:14,443Z target - INFO replicated 2305 records from "leads" endpoint
2026-06-17 14:17:14,572Z    tap - CRITICAL ("Connection broken: BrokenPipeError(32, 'Broken pipe')", BrokenPipeError(32, 'Broken pipe'))
```

Marketo's bulk API supports a `Range` header to support [resuming downloads](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/bulk-extract/bulk-extract#partial-retrieval-and-resumption) on a snapped connection. This PR catches the exception and attempts to resume the download from where it left off.

# Manual QA steps
I tested this locally with a dummy target that puts back pressure on the connection by sleeping 60 seconds after every 100 rows.

```
(defn -main [output & _]
  (with-open [rdr (io/reader *in*)]
    (doseq [[idx line] (map-indexed vector (line-seq rdr))
            :let [row (inc idx)]]
      (spit output (str line \newline) :append true)
      (when (zero? (rem row 100))
        (println "processed" row "rows")
        (println "sleeping 60 seconds...")
        (Thread/sleep 60000)))))
```

You can see the downloads resuming in the tap logs:

```
...
INFO Download starting.
INFO GET: https://708-hkn-232.mktorest.com/bulk/v1/leads/export/5a6c4c87-71b8-4ad5-bd33-0cf0a1d69901/file.json
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.22302484512329102, "tags": {"endpoint": "leads_stream", "status": "succeeded"}}
WARNING Export download connection dropped after 786432 bytes; resuming from byte 786432: ('Connection broken: IncompleteRead(833447 bytes read, 29766526 more expected)', IncompleteRead(833447 bytes read, 29766526 more expected)).
INFO GET: https://708-hkn-232.mktorest.com/bulk/v1/leads/export/5a6c4c87-71b8-4ad5-bd33-0cf0a1d69901/file.json
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.5056178569793701, "tags": {"endpoint": "leads_stream", "status": "succeeded"}}
WARNING Export download connection dropped after 589824 bytes; resuming from byte 1376256: ('Connection broken: IncompleteRead(624457 bytes read, 29189084 more expected)', IncompleteRead(624457 bytes read, 29189084 more expected)).
INFO GET: https://708-hkn-232.mktorest.com/bulk/v1/leads/export/5a6c4c87-71b8-4ad5-bd33-0cf0a1d69901/file.json
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.5614099502563477, "tags": {"endpoint": "leads_stream", "status": "succeeded"}}
WARNING Export download connection dropped after 589824 bytes; resuming from byte 1966080: ('Connection broken: IncompleteRead(622153 bytes read, 28601564 more expected)', IncompleteRead(622153 bytes read, 28601564 more expected)).
...
```
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
