### PR TITLE
preserve quota-exceeded error message when aborting window shrinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 2.9.3
+  * Preserve API quota error when shrinking window to minimum value [#115](https://github.com/singer-io/tap-marketo/pull/115)
+
 # 2.9.2
   * Detect JSON errors returned by the export file endpoint instead of parsing them as CSV data [#114](https://github.com/singer-io/tap-marketo/pull/114)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 # 2.9.3
-  * Preserve API quota error when shrinking window to minimum value [#115](https://github.com/singer-io/tap-marketo/pull/115)
+  * Preserve API quota error when shrinking window to minimum value [#116](https://github.com/singer-io/tap-marketo/pull/116)
 
 # 2.9.2
   * Detect JSON errors returned by the export file endpoint instead of parsing them as CSV data [#114](https://github.com/singer-io/tap-marketo/pull/114)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-marketo',
-      version='2.9.2',
+      version='2.9.3',
       description='Singer.io tap for extracting data from the Marketo API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -157,11 +157,7 @@ def create_export_with_quota_backoff(create_fn, export_start, max_export_days):
             # in_days() floors to whole days, matching how we size windows.
             window_days = (export_end - export_start).in_days()
             if window_days <= MIN_EXPORT_DAYS:
-                raise ApiQuotaExceeded(
-                    ("Unable to create an export for the window starting {} "
-                     "within your Marketo API quota, even after shrinking it "
-                     "to {} day(s).").format(export_start.isoformat(),
-                                             window_days)) from e
+                raise e
             new_days = max(MIN_EXPORT_DAYS, window_days // 2)
             singer.log_warning(
                 "Hit Marketo API quota creating export; retrying with a "


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-31605

When the window size cannot be shrunk, the error message about the window being too small to shrink is confusing. This PR preserves the error message from the quota limit failure so there is more actionable information in the final error state / log message.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
