### PR TITLE
Added retry for brokenpipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 2.9.4
+  * Added retry for brokenpipe [#117](https://github.com/singer-io/tap-marketo/pull/116)
+
 # 2.9.3
   * Preserve API quota error when shrinking window to minimum value [#116](https://github.com/singer-io/tap-marketo/pull/116)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-marketo',
-      version='2.9.3',
+      version='2.9.4',
       description='Singer.io tap for extracting data from the Marketo API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -198,9 +198,9 @@ class IterStream(io.RawIOBase):
             return len(out)
         except StopIteration:
             return 0
-        except (ChunkedEncodingError, ConnectionError, BrokenPipeError, ProtocolError) as ex:
-            # Re-raise connection errors so they can be handled by resumable_iter_content
-            raise ex
+        except (ChunkedEncodingError, ConnectionError, BrokenPipeError, ProtocolError):
+            # Preserve original traceback for upstream handling.
+            raise
 
 MAX_EMPTY_RESUMES = 5
 

--- a/tap_marketo/sync.py
+++ b/tap_marketo/sync.py
@@ -3,6 +3,7 @@ import io
 import json
 import pendulum
 from requests.exceptions import ChunkedEncodingError, ConnectionError
+from urllib3.exceptions import ProtocolError
 
 import singer
 from singer import metadata
@@ -197,6 +198,9 @@ class IterStream(io.RawIOBase):
             return len(out)
         except StopIteration:
             return 0
+        except (ChunkedEncodingError, ConnectionError, BrokenPipeError, ProtocolError) as ex:
+            # Re-raise connection errors so they can be handled by resumable_iter_content
+            raise ex
 
 MAX_EMPTY_RESUMES = 5
 
@@ -221,7 +225,7 @@ def resumable_iter_content(client, stream_type, export_id):
                 start_byte += len(chunk)
                 yield chunk
             return
-        except (ChunkedEncodingError, ConnectionError) as ex:
+        except (ChunkedEncodingError, ConnectionError, BrokenPipeError, ProtocolError) as ex:
             if bytes_this_connection:
                 empty_resumes = 0
             else:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -6,6 +6,7 @@ import freezegun
 import pendulum
 from requests.exceptions import ChunkedEncodingError, ConnectionError
 import requests_mock
+from urllib3.exceptions import ProtocolError
 
 from tap_marketo.client import Client, ApiException, ApiQuotaExceeded
 from tap_marketo.discover import (discover_catalog,
@@ -630,15 +631,16 @@ class TestResumableDownload(unittest.TestCase):
     class ByteResponse:
         """Yields its data one byte at a time, optionally dropping the
         connection once a given number of bytes have been emitted."""
-        def __init__(self, data, fail_after=None):
+        def __init__(self, data, fail_after=None, exc_class=ChunkedEncodingError):
             self.data = data
             self.fail_after = fail_after
+            self.exc_class = exc_class
             self.closed = False
 
         def iter_content(self, decode_unicode=False, chunk_size=512):
             for i, b in enumerate(self.data):
                 if self.fail_after is not None and i >= self.fail_after:
-                    raise ChunkedEncodingError("connection dropped")
+                    raise self.exc_class("connection dropped")
                 yield bytes([b])
 
         def close(self):
@@ -693,6 +695,50 @@ class TestResumableDownload(unittest.TestCase):
                      for _ in range(MAX_EMPTY_RESUMES + 5)]
         client = self._client(responses)
         with self.assertRaises(ChunkedEncodingError):
+            list(stream_rows(client, 'leads', 'export-1'))
+        self.assertEqual(MAX_EMPTY_RESUMES + 1, client.stream_export.call_count)
+
+    def test_resumes_on_broken_pipe_error(self):
+        full = b'id,name\n1,Alice\n2,Bob\n'
+        split = full.index(b'2,Bob')
+        client = self._client([
+            self.ByteResponse(full, fail_after=split, exc_class=BrokenPipeError),
+            self.ByteResponse(full[split:]),
+        ])
+
+        rows = list(stream_rows(client, 'leads', 'export-1'))
+
+        self.assertEqual([{'id': '1', 'name': 'Alice'}, {'id': '2', 'name': 'Bob'}], rows)
+        self.assertEqual(split, client.stream_export.call_args_list[1].kwargs['start_byte'])
+        self.assertEqual(2, client.stream_export.call_count)
+
+    def test_gives_up_after_repeated_zero_progress_broken_pipe(self):
+        responses = [self.ByteResponse(b'id\n1\n', fail_after=0, exc_class=BrokenPipeError)
+                     for _ in range(MAX_EMPTY_RESUMES + 5)]
+        client = self._client(responses)
+        with self.assertRaises(BrokenPipeError):
+            list(stream_rows(client, 'leads', 'export-1'))
+        self.assertEqual(MAX_EMPTY_RESUMES + 1, client.stream_export.call_count)
+
+    def test_resumes_on_protocol_error(self):
+        full = b'id,name\n1,Alice\n2,Bob\n'
+        split = full.index(b'2,Bob')
+        client = self._client([
+            self.ByteResponse(full, fail_after=split, exc_class=ProtocolError),
+            self.ByteResponse(full[split:]),
+        ])
+
+        rows = list(stream_rows(client, 'leads', 'export-1'))
+
+        self.assertEqual([{'id': '1', 'name': 'Alice'}, {'id': '2', 'name': 'Bob'}], rows)
+        self.assertEqual(split, client.stream_export.call_args_list[1].kwargs['start_byte'])
+        self.assertEqual(2, client.stream_export.call_count)
+
+    def test_gives_up_after_repeated_zero_progress_protocol_error(self):
+        responses = [self.ByteResponse(b'id\n1\n', fail_after=0, exc_class=ProtocolError)
+                     for _ in range(MAX_EMPTY_RESUMES + 5)]
+        client = self._client(responses)
+        with self.assertRaises(ProtocolError):
             list(stream_rows(client, 'leads', 'export-1'))
         self.assertEqual(MAX_EMPTY_RESUMES + 1, client.stream_export.call_count)
 


### PR DESCRIPTION
# Description of change
This PR expands the set of connection-related exceptions treated as retryable during Marketo bulk export downloads, aiming to make the resumable download logic handle “broken pipe” style disconnects more reliably.

Changes:

- Add urllib3.exceptions.ProtocolError handling alongside existing requests streaming exceptions.
- Treat BrokenPipeError and ProtocolError as retryable in resumable_iter_content.
- Add a matching exception path in IterStream.readinto so these exceptions propagate upward.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
